### PR TITLE
Added GoSquared support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,87 @@ Just integrate the handler with your matching account_id and you will be ready t
   end
 ```
 
+### GoSquared
+
+To enable GoSquared tracking:
+
+```ruby
+config.middleware.use(Rack::Tracker) do
+  handler :go_squared, { tracker: 'ABCDEFGH' }
+end
+````
+
+This will add the tracker to the page like so:
+
+``` javascript
+  _gs('ABCDEFGH');
+```
+
+You can also set multiple named trackers if need be:
+
+```ruby
+config.middleware.use(Rack::Tracker) do
+  handler :go_squared, {
+    trackers: {
+      primaryTracker: 'ABCDEFGH',
+      secondaryTracker: '1234567',
+    }
+  }
+end
+````
+
+This will add the specified trackers to the page like so:
+
+``` javascript
+  _gs('ABCDEFGH', 'primaryTracker');
+  _gs('1234567', 'secondaryTracker');
+```
+
+You can set [a variety of options](https://www.gosquared.com/developer/tracker/configuration/) by passing the following settings. If you don't set any of the following options, they will be omitted from the rendered code.
+
+* `:anonymize_ip`
+* `:cookie_domain`
+* `:use_cookies`
+* `:track_hash`
+* `:track_local`
+* `:track_params`
+
+#### Visitor Name
+
+To track the [visitor name](https://www.gosquared.com/developer/tracker/tagging/) from the server side, just call the `tracker` method in your controller.
+
+```ruby
+  def show
+    tracker do |t|
+      t.go_squared :visitor_name, { name: 'John Doe' }
+    end
+  end
+```
+
+It will render the following to the site source:
+
+```javascript
+  _gs("set", "visitorName", "John Doe");
+```
+
+#### Visitor Properties
+
+To track [visitor properties](https://www.gosquared.com/developer/tracker/tagging/) from the server side, just call the `tracker` method in your controller.
+
+```ruby
+  def show
+    tracker do |t|
+      t.go_squared :visitor_info, { age: 35, favorite_food: 'pizza' }
+    end
+  end
+```
+
+It will render the following to the site source:
+
+```javascript
+  _gs("set", "visitor", { "age": 35, "favorite_food": "pizza" });
+```
+
 ### Custom Handlers
 
 Tough we give you Google Analytics and Facebook right out of the box, you might

--- a/lib/rack/tracker.rb
+++ b/lib/rack/tracker.rb
@@ -3,6 +3,7 @@ require "tilt"
 require "active_support/core_ext/class/attribute"
 require "active_support/core_ext/hash"
 require "active_support/json"
+require "active_support/inflector"
 
 require "rack/tracker/version"
 require "rack/tracker/extensions"
@@ -13,6 +14,7 @@ require "rack/tracker/controller"
 require "rack/tracker/google_analytics/google_analytics"
 require "rack/tracker/facebook/facebook"
 require "rack/tracker/vwo/vwo"
+require "rack/tracker/go_squared/go_squared"
 
 module Rack
   class Tracker

--- a/lib/rack/tracker/go_squared/go_squared.rb
+++ b/lib/rack/tracker/go_squared/go_squared.rb
@@ -1,0 +1,37 @@
+class Rack::Tracker::GoSquared < Rack::Tracker::Handler
+  class VisitorName < OpenStruct
+    def write
+      ['set', 'visitorName', self.name].to_json.gsub(/\[|\]/, '')
+    end
+  end
+
+  class VisitorInfo < OpenStruct
+    def write
+      ['set', 'visitor', to_h].to_json.gsub(/\[|\]/, '')
+    end
+  end
+
+  def tracker
+    options[:tracker]
+  end
+
+  def trackers
+    options[:trackers]
+  end
+
+  def render
+    Tilt.new( File.join( File.dirname(__FILE__), 'template', 'go_squared.erb') ).render(self)
+  end
+
+  def visitor_name
+    events.select{|e| e.kind_of?(VisitorName) }.first
+  end
+
+  def visitor_info
+    events.select{|e| e.kind_of?(VisitorInfo) }.first
+  end
+
+  def self.track(name, *event)
+    { name.to_s => [const_get(event.first.to_s.classify).new(event.last)] }
+  end
+end

--- a/lib/rack/tracker/go_squared/template/go_squared.erb
+++ b/lib/rack/tracker/go_squared/template/go_squared.erb
@@ -1,0 +1,47 @@
+<script>
+  !function(g,s,q,r,d){r=g[r]=g[r]||function(){(r.q=r.q||[]).push(
+  arguments)};d=s.createElement(q);q=s.getElementsByTagName(q)[0];
+  d.src='//d1l6p2sc9645hc.cloudfront.net/tracker.js';q.parentNode.
+  insertBefore(d,q)}(window,document,'script','_gs');
+  <% if tracker %>
+  _gs('<%= tracker %>');
+  <% end %>
+
+  <% if trackers %>
+  <% trackers.each do |name, code| %>
+  _gs('<%= code %>', '<%= name %>');
+  <% end %>
+  <% end %>
+
+  <% if options[:anonymize_ip] %>
+    _gs('set', 'anonymizeIp', <%= options[:anonymize_ip] %>);
+  <% end %>
+
+  <% if options[:cookie_domain] %>
+    _gs('set', 'cookieDomain', '<%= options[:cookie_domain] %>');
+  <% end %>
+
+  <% if options[:use_cookies] %>
+    _gs('set', 'useCookies', <%= options[:use_cookies] %>);
+  <% end %>
+
+  <% if options[:track_hash] %>
+    _gs('set', 'trackHash', <%= options[:track_hash] %>);
+  <% end %>
+
+  <% if options[:track_local] %>
+    _gs('set', 'trackLocal', <%= options[:track_local] %>);
+  <% end %>
+
+  <% if options[:track_params] %>
+    _gs('set', 'trackParams', <%= options[:track_params] %>);
+  <% end %>
+
+  <% if visitor_name %>
+  _gs(<%= visitor_name.write() %>);
+  <% end %>
+
+  <% if visitor_info %>
+  _gs(<%= visitor_info.write() %>);
+  <% end %>
+</script>

--- a/spec/handler/go_squared_spec.rb
+++ b/spec/handler/go_squared_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe Rack::Tracker::GoSquared do
+
+  def env
+    {misc: 'foobar'}
+  end
+
+  it 'will be placed in the head' do
+    expect(described_class.position).to eq(:head)
+    expect(described_class.new(env).position).to eq(:head)
+  end
+
+  describe "with events" do
+    describe "visitor name" do
+      def env
+        {'tracker' => {
+          'go_squared' => [
+            Rack::Tracker::GoSquared::VisitorName.new(name: "John Doe")
+          ]
+        }}
+      end
+
+      subject { described_class.new(env, tracker: '12345').render }
+
+      it "will show the right name" do
+        expect(subject).to match(%r{_gs\(\"set\",\"visitorName\",\"John Doe\"\)})
+      end
+    end
+
+    describe "visitor details" do
+      def env
+        {'tracker' => {
+          'go_squared' => [
+            Rack::Tracker::GoSquared::VisitorInfo.new(age: 35, favorite_food: 'pizza')
+          ]
+        }}
+      end
+
+      subject { described_class.new(env, tracker: '12345').render }
+
+      it "will show the right properties" do
+        expect(subject).to match(%r{_gs\(\"set\",\"visitor\",{\"age\":35,\"favorite_food\":\"pizza\"}\)})
+      end
+    end
+  end
+
+end

--- a/spec/integration/go_squared_integration_spec.rb
+++ b/spec/integration/go_squared_integration_spec.rb
@@ -1,0 +1,79 @@
+require 'support/metal_controller'
+require 'support/fake_handler'
+
+RSpec.describe "GoSquared Integration" do
+  def setup_go_squared_app(options = {})
+    Capybara.app = Rack::Builder.new do
+      use Rack::Tracker do
+        handler :go_squared, options
+      end
+      run MetalController.action(:go_squared)
+    end
+  end
+
+  subject { page }
+
+  before do
+    setup_go_squared_app(
+      tracker: '123456',
+      anonymize_ip: true,
+      cookie_domain: 'domain.com',
+      use_cookies: true,
+      track_hash: true,
+      track_local: true,
+      track_params: true
+    )
+    visit '/'
+  end
+
+  it "adds the tracker to the page" do
+    expect(page).to have_content("_gs('123456');")
+  end
+
+  it "adds the visitorName to the page" do
+    expect(page).to have_content('_gs("set","visitorName","John Doe");')
+  end
+
+  it "adds the visitor to the page" do
+    expect(page).to have_content('_gs("set","visitor",{"age":35,"favorite_food":"pizza"});')
+  end
+
+  it "sets anonymizeIp" do
+    expect(page).to have_content("_gs('set', 'anonymizeIp', true);")
+  end
+
+  it "sets cookieDomain" do
+    expect(page).to have_content("_gs('set', 'cookieDomain', 'domain.com');")
+  end
+
+  it "sets useCookies" do
+    expect(page).to have_content("_gs('set', 'useCookies', true);")
+  end
+
+  it "sets trackHash" do
+    expect(page).to have_content("_gs('set', 'trackHash', true);")
+  end
+
+  it "sets trackLocal" do
+    expect(page).to have_content("_gs('set', 'trackLocal', true);")
+  end
+
+  it "sets trackParams" do
+    expect(page).to have_content("_gs('set', 'trackParams', true);")
+  end
+
+  context 'multiple trackers are passed in' do
+    before do
+      setup_go_squared_app(trackers: {
+        primaryTracker: '12345',
+        secondaryTracker: '67890'
+      })
+      visit '/'
+    end
+
+    it "adds the tracker to the page" do
+      expect(page).to have_content("_gs('12345', 'primaryTracker');")
+      expect(page).to have_content("_gs('67890', 'secondaryTracker');")
+    end
+  end
+end

--- a/spec/support/metal_controller.rb
+++ b/spec/support/metal_controller.rb
@@ -33,4 +33,12 @@ class MetalController < ActionController::Metal
   def vwo
     render "metal/index"
   end
+
+  def go_squared
+    tracker do |t|
+      t.go_squared :visitor_name, { name: 'John Doe' }
+      t.go_squared :visitor_info, { age: 35, favorite_food: 'pizza' }
+    end
+    render "metal/index"
+  end
 end


### PR DESCRIPTION
This PR adds fairly comprehensive support for [GoSquared](https://www.gosquared.com) analytics tracking. The following features are supported:
- Basic integration
- Multiple named trackers
- [Basic configuration parameters](https://www.gosquared.com/developer/tracker/configuration/)
- [Visitor Tagging](https://www.gosquared.com/developer/tracker/tagging/)
