### PR TITLE
stringify ga_event values

### DIFF
--- a/lib/rack/tracker/extensions.rb
+++ b/lib/rack/tracker/extensions.rb
@@ -6,3 +6,12 @@ class OpenStruct
     @table.dup
   end unless method_defined? :to_h
 end
+
+class Hash
+  def stringify_values
+    inject({}) do |options, (key, value)|
+      options[key] = value.to_s
+      options
+    end
+  end
+end

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -10,7 +10,7 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
     end
 
     def event
-      { hitType: self.type }.merge(attributes).compact
+      { hitType: self.type }.merge(attributes.stringify_values).compact
     end
 
     def attributes
@@ -20,7 +20,7 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
 
   class Ecommerce < OpenStruct
     def write
-      ["ecommerce:#{self.type}", self.to_h.except(:type).compact].to_json.gsub(/\[|\]/, '')
+      ["ecommerce:#{self.type}", self.to_h.except(:type).compact.stringify_values].to_json.gsub(/\[|\]/, '')
     end
   end
 

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
     describe "with a event value" do
       def env
         {'tracker' => { 'google_analytics' => [
-          Rack::Tracker::GoogleAnalytics::Send.new(category: "Users", action: "Login", label: "Standard", value: 5)
+          Rack::Tracker::GoogleAnalytics::Send.new(category: "Users", action: "Login", label: "Standard", value: "5")
         ]}}
       end
 
       subject { described_class.new(env, tracker: 'somebody').render }
       it "will show events with values" do
-        expect(subject).to match(%r{ga\(\"send\",{\"hitType\":\"event\",\"eventCategory\":\"Users\",\"eventAction\":\"Login\",\"eventLabel\":\"Standard\",\"eventValue\":5}\)},)
+        expect(subject).to match(%r{ga\(\"send\",{\"hitType\":\"event\",\"eventCategory\":\"Users\",\"eventAction\":\"Login\",\"eventLabel\":\"Standard\",\"eventValue\":\"5\"}\)},)
       end
     end
   end
@@ -75,7 +75,7 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
         expect(subject).to match(%r{ga\(\"ecommerce:addItem\",#{{id: '1234', name: 'Fluffy Pink Bunnies', sku: 'DD23444', category: 'Party Toys', price: '11.99', quantity: '1'}.to_json}})
       end
       it "will add transaction" do
-        expect(subject).to match(%r{ga\(\"ecommerce:addTransaction\",#{{id: '1234', affiliation: 'Acme Clothing', revenue: 11.99, shipping: '5', tax: '1.29', currency: 'EUR'}.to_json}})
+        expect(subject).to match(%r{ga\(\"ecommerce:addTransaction\",#{{id: '1234', affiliation: 'Acme Clothing', revenue: '11.99', shipping: '5', tax: '1.29', currency: 'EUR'}.to_json}})
       end
       it "will submit cart" do
         expect(subject).to match(%r{ga\('ecommerce:send'\);})

--- a/spec/integration/google_analytics_integration_spec.rb
+++ b/spec/integration/google_analytics_integration_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "Facebook Integration" do
   subject { page }
 
   it "embeds the script tag with tracking event from the controller action" do
-    expect(page).to have_content('ga("ecommerce:addItem",{"id":"1234","affiliation":"Acme Clothing","revenue":"11.99","shipping":"5","tax":"1.29"})')
+    expect(page).to have_content('ga("ecommerce:addItem",{"id":"1234","name":"Fluffy Pink Bunnies","sku":"DD23444","category":"Party Toys","price":"11.99","quantity":"1"})')
+    expect(page).to have_content('ga("ecommerce:addTransaction",{"id":"1234","affiliation":"Acme Clothing","revenue":"11.99","shipping":"5","tax":"1.29"})')
     expect(page).to have_content('ga("send",{"hitType":"event","eventCategory":"button","eventAction":"click","eventLabel":"nav-buttons","eventValue":"X"})')
   end
 end

--- a/spec/support/metal_controller.rb
+++ b/spec/support/metal_controller.rb
@@ -24,7 +24,8 @@ class MetalController < ActionController::Metal
 
   def google_analytics
     tracker do |t|
-      t.google_analytics :ecommerce, { type: 'addItem', id: '1234', affiliation: 'Acme Clothing', revenue: '11.99', shipping: '5', tax: '1.29' }
+      t.google_analytics :ecommerce, { type: 'addTransaction', id: 1234, affiliation: 'Acme Clothing', revenue: 11.99, shipping: 5, tax: 1.29 }
+      t.google_analytics :ecommerce, { type: 'addItem', id: 1234, name: 'Fluffy Pink Bunnies', sku: 'DD23444', category: 'Party Toys', price: 11.99, quantity: 1 }
       t.google_analytics :send, { type: 'event', category: 'button', action: 'click', label: 'nav-buttons', value: 'X' }
     end
     render "metal/index"


### PR DESCRIPTION
because when we add integers or floats to the tracker which is being send to GA, 
the values should be send as strings in the javascript.
