### PR TITLE
Support added for Rails 4.2.

### DIFF
--- a/rack-tracker.gemspec
+++ b/rack-tracker.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rack", "~> 1.5.2"
+  spec.add_dependency "rack", ">= 1.5.2"
   spec.add_dependency "tilt", "~> 1.4.1"
   spec.add_dependency "activesupport", ">= 4.0.0"
 


### PR DESCRIPTION
`Rails 4.2.0.beta2` has updated `rack` to `1.6.0.beta`, so `rack` need change the version to `>= 1.5.2`.

```
Bundler could not find compatible versions for gem "rack":
  In Gemfile:
    rack-tracker (~> 0.2.3) ruby depends on
      rack (~> 1.5.2) ruby

    rails (= 4.2.0.beta2) ruby depends on
      actionpack (= 4.2.0.beta2) ruby depends on
        rack (1.6.0.beta)
```
