### PR TITLE
Only work with stringified keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ to inject arbitrary events into the request environment.
 ```ruby
 request.env['tracker'] = {
   'google_analytics' => [
-    Rack::Tracker::GoogleAnalytics::Send.new(category: "Users", action: "Login", label: "Standard")
+    { 'class_name' => 'Send', 'category' => 'Users', 'action' => 'Login', 'label' => 'Standard' }
   ]
 }
 ```

--- a/lib/rack/tracker/facebook/facebook.rb
+++ b/lib/rack/tracker/facebook/facebook.rb
@@ -12,7 +12,7 @@ class Rack::Tracker::Facebook < Rack::Tracker::Handler
   end
 
   def self.track(name, *event)
-    { name.to_s => [event.last.merge(class_name: 'Event')] }
+    { name.to_s => [event.last.deep_stringify_keys.merge('class_name' => 'Event')] }
   end
 
 end

--- a/lib/rack/tracker/facebook/facebook.rb
+++ b/lib/rack/tracker/facebook/facebook.rb
@@ -12,7 +12,7 @@ class Rack::Tracker::Facebook < Rack::Tracker::Handler
   end
 
   def self.track(name, *event)
-    { name.to_s => [event.last.deep_stringify_keys.merge('class_name' => 'Event')] }
+    { name.to_s => [event.last.merge('class_name' => 'Event')] }
   end
 
 end

--- a/lib/rack/tracker/go_squared/go_squared.rb
+++ b/lib/rack/tracker/go_squared/go_squared.rb
@@ -32,6 +32,6 @@ class Rack::Tracker::GoSquared < Rack::Tracker::Handler
   end
 
   def self.track(name, *event)
-    { name.to_s => [event.last.deep_stringify_keys.merge('class_name' => event.first.to_s.classify)] }
+    { name.to_s => [event.last.merge('class_name' => event.first.to_s.classify)] }
   end
 end

--- a/lib/rack/tracker/go_squared/go_squared.rb
+++ b/lib/rack/tracker/go_squared/go_squared.rb
@@ -32,6 +32,6 @@ class Rack::Tracker::GoSquared < Rack::Tracker::Handler
   end
 
   def self.track(name, *event)
-    { name.to_s => [event.last.merge(class_name: event.first.to_s.classify)] }
+    { name.to_s => [event.last.deep_stringify_keys.merge('class_name' => event.first.to_s.classify)] }
   end
 end

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -50,6 +50,6 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
   end
 
   def self.track(name, *event)
-    { name.to_s => [event.last.merge(class_name: event.first.to_s.capitalize)] }
+    { name.to_s => [event.last.deep_stringify_keys.merge('class_name' => event.first.to_s.capitalize)] }
   end
 end

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -50,6 +50,6 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
   end
 
   def self.track(name, *event)
-    { name.to_s => [event.last.deep_stringify_keys.merge('class_name' => event.first.to_s.capitalize)] }
+    { name.to_s => [event.last.merge('class_name' => event.first.to_s.capitalize)] }
   end
 end

--- a/lib/rack/tracker/handler.rb
+++ b/lib/rack/tracker/handler.rb
@@ -13,7 +13,7 @@ class Rack::Tracker::Handler
 
   def events
     events = env.fetch('tracker', {})[self.class.to_s.demodulize.underscore] || []
-    events.map{ |ev| "#{self.class}::#{ev[:class_name]}".constantize.new(ev.except(:class_name)) }
+    events.map{ |ev| "#{self.class}::#{ev['class_name']}".constantize.new(ev.except('class_name')) }
   end
 
   def render

--- a/lib/rack/tracker/handler_delegator.rb
+++ b/lib/rack/tracker/handler_delegator.rb
@@ -20,6 +20,7 @@ class Rack::Tracker::HandlerDelegator
   end
 
   def write_event(event)
+    event.deep_stringify_keys! # for consistency
     if env.key?('tracker')
       self.env['tracker'].deep_merge!(event) { |key, old, new| Array.wrap(old) + Array.wrap(new) }
     else

--- a/lib/rack/tracker/handler_delegator.rb
+++ b/lib/rack/tracker/handler_delegator.rb
@@ -20,7 +20,7 @@ class Rack::Tracker::HandlerDelegator
   end
 
   def write_event(event)
-    event.deep_stringify_keys! # for consistency
+    event.deep_stringify_keys! # for consistent hash access use strings (keys from the session are always strings anyway)
     if env.key?('tracker')
       self.env['tracker'].deep_merge!(event) { |key, old, new| Array.wrap(old) + Array.wrap(new) }
     else

--- a/spec/fixtures/track_all_the_things.erb
+++ b/spec/fixtures/track_all_the_things.erb
@@ -1,3 +1,3 @@
 <script type="text/javascript">
-  myAwesomeFunction("tracks", "like", "<%= track_me[:like] %>", "<%= options[:custom_key] %>");
+  myAwesomeFunction("tracks", "like", "<%= track_me['like'] %>", "<%= options[:custom_key] %>");
 </script>

--- a/spec/handler/facebook_spec.rb
+++ b/spec/handler/facebook_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe Rack::Tracker::Facebook do
         'facebook' =>
           [
             {
-              id: '123456789',
-              value: '23',
-              currency: 'EUR',
-              class_name: 'Event'
+              'id' => '123456789',
+              'value' => '23',
+              'currency' => 'EUR',
+              'class_name' => 'Event'
             }
           ]
         }

--- a/spec/handler/go_squared_spec.rb
+++ b/spec/handler/go_squared_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Rack::Tracker::GoSquared do
       def env
         {'tracker' => {
           'go_squared' => [
-            { class_name: 'VisitorName', name: 'John Doe' }
+            { 'class_name' => 'VisitorName', 'name' => 'John Doe' }
           ]
         }}
       end
@@ -30,7 +30,7 @@ RSpec.describe Rack::Tracker::GoSquared do
       def env
         {'tracker' => {
           'go_squared' => [
-            { class_name: 'VisitorInfo', age: 35, favorite_food: 'pizza' }
+            { 'class_name' => 'VisitorInfo', 'age' => 35, 'favorite_food' => 'pizza' }
           ]
         }}
       end

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
       def env
         {'tracker' => {
           'google_analytics' => [
-            { class_name: 'Send', category: "Users", action: "Login", label: "Standard" }
+            { 'class_name' => 'Send', 'category' => 'Users', 'action' => 'Login', 'label' => 'Standard' }
           ]
         }}
       end
@@ -90,7 +90,7 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
     describe "with a event value" do
       def env
         {'tracker' => { 'google_analytics' => [
-          { class_name: 'Send', category: "Users", action: "Login", label: "Standard", value: "5" }
+          { 'class_name' => 'Send', category: "Users", action: "Login", label: "Standard", value: "5" }
         ]}}
       end
 
@@ -106,8 +106,8 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
       def env
         {'tracker' => {
           'google_analytics' => [
-            { class_name: 'Ecommerce', type: 'addItem', id: '1234', name: 'Fluffy Pink Bunnies', sku: 'DD23444', category: 'Party Toys', price: '11.99', quantity: '1' },
-            { class_name: 'Ecommerce', type: 'addTransaction', id: '1234', affiliation: 'Acme Clothing', revenue: 11.99, shipping: '5', tax: '1.29', currency: 'EUR' }
+            { 'class_name' => 'Ecommerce', 'type' => 'addItem', 'id' => '1234', 'name' => 'Fluffy Pink Bunnies', 'sku' => 'DD23444', 'category' => 'Party Toys', 'price' => '11.99', 'quantity' => '1' },
+            { 'class_name' => 'Ecommerce', 'type' => 'addTransaction', 'id' => '1234', 'affiliation' => 'Acme Clothing', 'revenue' => 11.99, 'shipping' => '5', 'tax' => '1.29', 'currency' => 'EUR' }
           ]
         }}
       end

--- a/spec/tracker/controller_spec.rb
+++ b/spec/tracker/controller_spec.rb
@@ -22,11 +22,11 @@ end
 
 RSpec.describe Rack::Tracker::Controller do
   describe '#tracker' do
-    let(:send)       { { class_name: 'Send', category: 'foo' } }
-    let(:trx)        { { class_name: 'Ecommerce', type: 'addTransaction', some: 'thing' } }
-    let(:item_foo)   { { class_name: 'Ecommerce', type: 'addItem', name: 'foo' } }
-    let(:item_bar)   { { class_name: 'Ecommerce', type: 'addItem', name: 'bar' } }
-    let(:fb_event)   { { class_name: 'Event', id: '1', value: 1, currency: 'USD' } }
+    let(:send)       { { 'category' => 'foo', 'class_name' => 'Send' } }
+    let(:trx)        { { 'type' => 'addTransaction', 'some' => 'thing', 'class_name' => 'Ecommerce' } }
+    let(:item_foo)   { { 'type' => 'addItem', 'name' => 'foo', 'class_name' => 'Ecommerce' } }
+    let(:item_bar)   { { 'type' => 'addItem', 'name' => 'bar', 'class_name' => 'Ecommerce' } }
+    let(:fb_event)   { { 'id' => '1', 'value' => 1, 'currency' => 'USD', 'class_name' => 'Event' } }
     let(:controller) { TestController.new({}) }
 
     context 'controller' do


### PR DESCRIPTION
Stringify all the incomming hash keys from the `track()` methods and only work with string keys internally.

The reason is that hashes coming from the Rails session will always have string keys and this way it's consistent everwhere internally in the gem.