### PR TITLE
send proper url with turbolinks enabled

### DIFF
--- a/lib/rack/tracker/google_analytics/template/google_analytics.erb
+++ b/lib/rack/tracker/google_analytics/template/google_analytics.erb
@@ -43,7 +43,13 @@
 <% end %>
 
 <% if tracker %>
-  ga('send', 'pageview');
+  if(typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
+    $(document).on('page:change', function() {
+      ga('send', 'pageview', window.location.pathname);
+    });
+  } else {
+    ga('send', 'pageview');
+  }
 <% end %>
 
 </script>


### PR DESCRIPTION
Simple `ga('send', 'pageview')` cannot account for `turbolinks` page changes, it always sends the same url that was loaded during the full page load. This modification will allow sending the proper url on turbolinks page changes. Full page reload also calls `page:change` event so it will work for that too. It falls back to the default implementation if `turbonlinks` is not enabled or supported.

Note: It uses jquery `on` event instead of `addEventListener` to avoid cross browser issues. As rails developers use `jquery-turbolinks` gem, i think it wont be an issue.