### PR TITLE
google analytics: allow set parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ It will render the following to the site source:
   ga('send', { 'hitType': 'event', 'eventCategory': 'button', 'eventAction': 'click', 'eventLabel': 'nav-buttons', 'value': 'X' })
 ```
 
+#### Parameters
+
+You can set parameters in your controller too:
+
+```ruby
+  def show
+    tracker do |t|
+      t.google_analytics :parameter, { dimension1: 'pink' }
+    end
+  end
+```
+
+Will render this:
+
+```javascript
+  ga('set', 'dimension1', 'pink');
+```
+
+
+
 #### Ecommerce
 
 You can even trigger ecommerce directly from within your controller:

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -27,6 +27,12 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
     end
   end
 
+  class Parameter < OpenStruct
+    def write
+      ["set", self.to_h.to_a].flatten.map {|s| "'#{s}'" }.join(', ')
+    end
+  end
+
   def tracker
     options[:tracker].respond_to?(:call) ? options[:tracker].call(env) : options[:tracker]
   end

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe Rack::Tracker::GoogleAnalytics do
-
   def env
     {
       misc: 'foobar',
@@ -125,6 +124,22 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
     end
   end
 
+  describe 'with parameters events' do
+    def env
+      {'tracker' => {
+        'google_analytics' => [
+          { 'class_name' => 'Parameter', 'dimension1' => 'pink' },
+        ]
+      }}
+    end
+
+    subject { described_class.new(env, tracker: 'somebody').render }
+
+    it "will render dimension parameter" do
+      expect(subject).to match(%r{ga\('set', 'dimension1', 'pink'})
+    end
+  end
+
   describe "with custom domain" do
     subject { described_class.new(env, tracker: 'somebody', cookie_domain: "railslabs.com").render }
 
@@ -191,5 +206,4 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
       expect(subject).to match(%r{ga\('send', 'event', '30_seconds', 'read'\)})
     end
   end
-
 end


### PR DESCRIPTION
This change makes it possible to set parameters such as dimension or metric see https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#customs