### PR TITLE
google analytics: render enhanced ecommerce requirement without any events and able to pass label for action event

### DIFF
--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -23,7 +23,8 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
 
   class EnhancedEcommerce < OpenStruct
     def write
-      ["ec:#{self.type}", self.to_h.except(:type).compact.stringify_values].to_json.gsub(/\[|\]/, '')
+      hash = self.to_h
+      ["ec:#{self.type}", hash[:label], hash.except(:label, :type).compact.stringify_values].compact.to_json.gsub(/\[|\]/, '')
     end
   end
 

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -24,13 +24,25 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
   class EnhancedEcommerce < OpenStruct
     def write
       hash = self.to_h
-      ["ec:#{self.type}", hash[:label], hash.except(:label, :type).compact.stringify_values].compact.to_json.gsub(/\[|\]/, '')
+      label = hash[:label]
+      attributes = hash.except(:label, :type).compact.stringify_values
+
+      [
+        "ec:#{self.type}",
+        label,
+        attributes.empty? ? nil : attributes
+      ].compact.to_json.gsub(/\[|\]/, '')
     end
   end
 
   class Ecommerce < OpenStruct
     def write
-      ["ecommerce:#{self.type}", self.to_h.except(:type).compact.stringify_values].to_json.gsub(/\[|\]/, '')
+      attributes = self.to_h.except(:type).compact.stringify_values
+
+      [
+        "ecommerce:#{self.type}",
+        attributes
+      ].to_json.gsub(/\[|\]/, '')
     end
   end
 

--- a/lib/rack/tracker/google_analytics/template/google_analytics.erb
+++ b/lib/rack/tracker/google_analytics/template/google_analytics.erb
@@ -14,7 +14,7 @@
 <% if options[:advertising] %>
   ga('require', 'displayfeatures');
 <% end %>
-<% if options[:enhanced_ecommerce] && enhanced_ecommerce_events.any? %>
+<% if options[:enhanced_ecommerce] %>
   ga('require', 'ec');
 <% end %>
 <% if options[:ecommerce] %>

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
         {'tracker' => {
           'google_analytics' => [
             { 'class_name' => 'EnhancedEcommerce', 'type' => 'addProduct', 'id' => 'P12345', 'name' => 'Android Warhol T-Shirt', 'category' => 'Apparel', 'brand' => 'Google', 'variant' => 'black', 'price' => '29.20', 'coupon' => 'APPARELSALE', 'quantity' => 1 },
-            { 'class_name' => 'EnhancedEcommerce', 'type' => 'setAction', 'id' => 'T12345', 'affiliation' => 'Google Store - Online', 'revenue' => '37.39', 'tax' => '2.85', 'shipping' => '5.34', 'coupon' => 'SUMMER2013' }
+            { 'class_name' => 'EnhancedEcommerce', 'type' => 'setAction', 'label' => 'purchase', 'id' => 'T12345', 'affiliation' => 'Google Store - Online', 'revenue' => '37.39', 'tax' => '2.85', 'shipping' => '5.34', 'coupon' => 'SUMMER2013' }
           ]
         }}
       end
@@ -161,7 +161,7 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
       end
 
       it "will add action" do
-        expect(subject).to match(%r{ga\(\"ec:setAction\",#{{id: 'T12345', affiliation: 'Google Store - Online', revenue: '37.39', tax: '2.85', shipping: '5.34', coupon: 'SUMMER2013'}.to_json}})
+        expect(subject).to match(%r{ga\(\"ec:setAction\",\"purchase\",#{{id: 'T12345', affiliation: 'Google Store - Online', revenue: '37.39', tax: '2.85', shipping: '5.34', coupon: 'SUMMER2013'}.to_json}})
       end
     end
   end

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -217,28 +217,10 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
   end
 
   describe "with enhanced ecommerce" do
-    describe "without events" do
-      subject { described_class.new(env, tracker: 'happy', enhanced_ecommerce: true).render }
+    subject { described_class.new(env, tracker: 'happy', enhanced_ecommerce: true).render }
 
-      it "will require the enhanced ecommerce plugin" do
-        expect(subject).to_not match(%r{ga\('require', 'ec'\)})
-      end
-    end
-
-    describe "with events" do
-      def env
-        {'tracker' => {
-          'google_analytics' => [
-            { 'class_name' => 'EnhancedEcommerce', 'type' => 'addProduct', 'id' => 'P12345', 'name' => 'Android Warhol T-Shirt', 'category' => 'Apparel', 'brand' => 'Google', 'variant' => 'black', 'price' => '29.20', 'coupon' => 'APPARELSALE', 'quantity' => 1 },
-          ]
-        }}
-      end
-
-      subject { described_class.new(env, tracker: 'happy', enhanced_ecommerce: true).render }
-
-      it "will require the enhanced ecommerce plugin" do
-        expect(subject).to match(%r{ga\('require', 'ec'\)})
-      end
+    it "will require the enhanced ecommerce plugin" do
+      expect(subject).to match(%r{ga\('require', 'ec'\)})
     end
   end
 

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -91,6 +91,8 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
   end
 
   describe "with events" do
+    subject { described_class.new(env, tracker: 'somebody').render }
+
     describe "default" do
       def env
         {'tracker' => {
@@ -100,7 +102,6 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
         }}
       end
 
-      subject { described_class.new(env, tracker: 'somebody').render }
       it "will show events" do
         expect(subject).to match(%r{ga\(\"send\",{\"hitType\":\"event\",\"eventCategory\":\"Users\",\"eventAction\":\"Login\",\"eventLabel\":\"Standard\"}\)})
       end
@@ -113,7 +114,6 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
         ]}}
       end
 
-      subject { described_class.new(env, tracker: 'somebody').render }
       it "will show events with values" do
         expect(subject).to match(%r{ga\(\"send\",{\"hitType\":\"event\",\"eventCategory\":\"Users\",\"eventAction\":\"Login\",\"eventLabel\":\"Standard\",\"eventValue\":\"5\"}\)},)
       end
@@ -132,12 +132,17 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
       end
 
       subject { described_class.new(env, tracker: 'somebody', ecommerce: true).render }
+
       it "will add items" do
-        expect(subject).to match(%r{ga\(\"ecommerce:addItem\",#{{id: '1234', name: 'Fluffy Pink Bunnies', sku: 'DD23444', category: 'Party Toys', price: '11.99', quantity: '1'}.to_json}})
+        attributes = { id: '1234', name: 'Fluffy Pink Bunnies', sku: 'DD23444', category: 'Party Toys', price: '11.99', quantity: '1' }.to_json
+        expect(subject).to match(%r{ga\(\"ecommerce:addItem\",#{attributes}\);})
       end
+
       it "will add transaction" do
-        expect(subject).to match(%r{ga\(\"ecommerce:addTransaction\",#{{id: '1234', affiliation: 'Acme Clothing', revenue: '11.99', shipping: '5', tax: '1.29', currency: 'EUR'}.to_json}})
+        attributes = { id: '1234', affiliation: 'Acme Clothing', revenue: '11.99', shipping: '5', tax: '1.29', currency: 'EUR' }.to_json
+        expect(subject).to match(%r{ga\(\"ecommerce:addTransaction\",#{attributes}\);})
       end
+
       it "will submit cart" do
         expect(subject).to match(%r{ga\('ecommerce:send'\);})
       end
@@ -150,18 +155,20 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
         {'tracker' => {
           'google_analytics' => [
             { 'class_name' => 'EnhancedEcommerce', 'type' => 'addProduct', 'id' => 'P12345', 'name' => 'Android Warhol T-Shirt', 'category' => 'Apparel', 'brand' => 'Google', 'variant' => 'black', 'price' => '29.20', 'coupon' => 'APPARELSALE', 'quantity' => 1 },
-            { 'class_name' => 'EnhancedEcommerce', 'type' => 'setAction', 'label' => 'purchase', 'id' => 'T12345', 'affiliation' => 'Google Store - Online', 'revenue' => '37.39', 'tax' => '2.85', 'shipping' => '5.34', 'coupon' => 'SUMMER2013' }
+            { 'class_name' => 'EnhancedEcommerce', 'type' => 'setAction', 'label' => 'purchase' }
           ]
         }}
       end
 
       subject { described_class.new(env, tracker: 'somebody', enhanced_ecommerce: true).render }
+
       it "will add product" do
-        expect(subject).to match(%r{ga\(\"ec:addProduct\",#{{id: 'P12345', name: 'Android Warhol T-Shirt', category: 'Apparel', brand: 'Google', variant: 'black', price: '29.20', coupon: 'APPARELSALE', quantity: '1'}.to_json}})
+        attributes = { id: 'P12345', name: 'Android Warhol T-Shirt', category: 'Apparel', brand: 'Google', variant: 'black', price: '29.20', coupon: 'APPARELSALE', quantity: '1' }.to_json
+        expect(subject).to match(%r{ga\(\"ec:addProduct\",#{attributes}\);})
       end
 
       it "will add action" do
-        expect(subject).to match(%r{ga\(\"ec:setAction\",\"purchase\",#{{id: 'T12345', affiliation: 'Google Store - Online', revenue: '37.39', tax: '2.85', shipping: '5.34', coupon: 'SUMMER2013'}.to_json}})
+        expect(subject).to match(%r{ga\(\"ec:setAction\",\"purchase\"\);})
       end
     end
   end

--- a/spec/integration/google_analytics_integration_spec.rb
+++ b/spec/integration/google_analytics_integration_spec.rb
@@ -28,6 +28,5 @@ RSpec.describe "Google Analytics Integration" do
      expect(page.find("head")).to_not have_content('U-XXX-Y')
      expect(page.find("body")).to have_content('ga("ecommerce:addItem",{"id":"1234","name":"Fluffy Pink Bunnies","sku":"DD23444","category":"Party Toys","price":"11.99","quantity":"1"})')
     end
-
   end
 end


### PR DESCRIPTION
- requirement is needed to render events with directly javascript
- label for action is needed for https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#action-types
- if no attributes given don't render empty hash