### PR TITLE
Add criteo to the list of supported services

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ but to get you started we're shipping support for the following services out of 
 * [Facebook](#facebook)
 * [Visual Website Optimizer (VWO)](#visual-website-optimizer-vwo)
 * [GoSquared](#gosquared)
+* [Criteo](#criteo)
 
 
 ## Installation


### PR DESCRIPTION
There was already a description how to use criteo, but the service was not mentioned in the list of supported services.