### PR TITLE
Add “manually_track_pageview” option to Google Analytics handler

### DIFF
--- a/lib/rack/tracker/google_analytics/template/google_analytics.erb
+++ b/lib/rack/tracker/google_analytics/template/google_analytics.erb
@@ -35,7 +35,7 @@
 <% if options[:ecommerce] && ecommerce_events.any? %>
   ga('ecommerce:send');
 <% end %>
-<% if tracker %>
+<% if tracker && !options[:manually_track_pageview] %>
   ga('send', 'pageview');
 <% end %>
 </script>

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -189,6 +189,15 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
     end
   end
 
+  describe "with manually pageview tracking option" do
+    subject { described_class.new(env, tracker: 'somebody', manually_track_pageview: true).render }
+
+    it "will show asyncronous tracker but without pageview command" do
+      expect(subject).to match(%r{ga\('create', 'somebody', {}\)})
+      expect(subject).not_to match(%r{ga\('send', 'pageview'\)})
+    end
+  end
+
   describe "with custom domain" do
     subject { described_class.new(env, tracker: 'somebody', cookie_domain: "railslabs.com").render }
 


### PR DESCRIPTION
This pull request adds a `manually_track_pageview` option. When used, it does not output the `ga('send', 'pageview')` line in the tracker code.

We’re using this to make the middleware play nice with [Turbolinks](https://github.com/rails/turbolinks) which does not evaluate `<script>` tags in the `<head>` when changing pages. This new `manually_track_pageview` option allows us to have this code in the `<head>`.

```html
<head>
  …

  <script type="text/javascript">
    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');

    ga('create', 'UA-0000000-01', {});
  </script>
</head>
<body>
  …
</body>
```

And manually track our pageviews in a `<script>` element at the end of our `<body>` (**which gets evaluated by Turbolinks when it changes the page content**)

```html
<head>
  …
</head>
<body>
  …
  <script>
    if (window.ga) { ga('send', 'pageview'); }
  </script>
</body>
```

What do you think? It doesn’t change existing behavior if the option is not used :smile: 