### PR TITLE
Send pageview command with whole URL

### DIFF
--- a/lib/rack/tracker/google_analytics/template/google_analytics.erb
+++ b/lib/rack/tracker/google_analytics/template/google_analytics.erb
@@ -36,6 +36,6 @@
   ga('ecommerce:send');
 <% end %>
 <% if tracker %>
-  ga('send', 'pageview');
+  ga('send', 'pageview', {'location': window.location.href});
 <% end %>
 </script>

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
 
     it "will show asyncronous tracker with cookieDomain" do
       expect(subject).to match(%r{ga\('create', 'somebody', {\"cookieDomain\":\"railslabs.com\"}\)})
-      expect(subject).to match(%r{ga\('send', 'pageview'\)})
+      expect(subject).to match(%r{ga\('send', 'pageview', {'location': window.location.href}\)})
     end
   end
 
@@ -203,7 +203,7 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
 
     it "will show asyncronous tracker with userId" do
       expect(subject).to match(%r{ga\('create', 'somebody', {\"userId\":\"123\"}\)})
-      expect(subject).to match(%r{ga\('send', 'pageview'\)})
+      expect(subject).to match(%r{ga\('send', 'pageview', {'location': window.location.href}\)})
     end
   end
 


### PR DESCRIPTION
When using Turbolinks, we have to require the template using `position: :body` so that the `<script>` tag will get re-evaluated between each page change.

However (as noted in #26), we have to specify the whole page URL when we send the `pageview` command because omitting it will only track the page from the original request.