### PR TITLE
Use deep_stringify_keys! when present

### DIFF
--- a/lib/rack/tracker/handler_delegator.rb
+++ b/lib/rack/tracker/handler_delegator.rb
@@ -20,7 +20,8 @@ class Rack::Tracker::HandlerDelegator
   end
 
   def write_event(event)
-    event.deep_stringify_keys! # for consistent hash access use strings (keys from the session are always strings anyway)
+    # for consistent hash access use strings (keys from the session are always strings anyway)
+    event.deep_stringify_keys! if event.respond_to?(:deep_stringify_keys!)
     if env.key?('tracker')
       self.env['tracker'].deep_merge!(event) { |key, old, new| Array.wrap(old) + Array.wrap(new) }
     else


### PR DESCRIPTION
Hi, there. At @stackbuilders we use `rack-tracker` for projects running on rails 3. We upgraded recently so that we could use the Google Adwords Conversion handler. However, we faced a problem because rails 3 doesn't have `deep_stringify_keys!`, hence we can't use it without changing this. We'd like to propose using the method only when present. Does that make any sense? Please let me know if I'm missing something.

Thanks!