### PR TITLE
Use default options from handler for GAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ in your application. It's easy to add your own [custom handlers](#custom-handler
 but to get you started we're shipping support for the following services out of the box:
 
 * [Google Analytics](#google-analytics)
+* [Google Adwords Conversion](#google-adwords-conversion)
 * [Google Tag Manager](#google-tag-manager)
 * [Facebook](#facebook)
 * [Visual Website Optimizer (VWO)](#visual-website-optimizer-vwo)
@@ -187,8 +188,44 @@ take care of the plugin on your own.
   config.middleware.use(Rack::Tracker) do
     handler :google_analytics, { tracker: 'U-XXXXX-Y', ecommerce: true }
   end
-````
+```
 
+### Google Adwords Conversion
+
+You can configure the handler with default options:
+```ruby
+config.middleware.use(Rack::Tracker) do
+  handler :google_adwords_conversion, { id: 123456,
+                                        language: "en",
+                                        format: "3",
+                                        color: "ffffff",
+                                        label: "Conversion label",
+                                        currency: "USD" }
+end
+```
+
+To track adwords conversion from the server side just call the `tracker` method in your controller.
+```ruby
+  def show
+    tracker do |t|
+      t.google_adwords_conversion :conversion, { value: 10.0 }
+    end
+  end
+```
+
+You can also specify a different value from default options:
+```ruby
+  def show
+    tracker do |t|
+      t.google_adwords_conversion :conversion, { id: 123456,
+                                                 language: 'en',
+                                                 format: '3',
+                                                 color: 'ffffff',
+                                                 label: 'Conversion Label',
+                                                 value: 10.0 }
+    end
+  end
+```
 
 ### Google Tag Manager
 
@@ -198,7 +235,7 @@ Google Tag manager code snippet doesn't support any option other than the contai
   config.middleware.use(Rack::Tracker) do
     handler :google_tag_manager, { container: 'GTM-XXXXXX' }
   end
-````
+```
 
 #### Data Layer
 

--- a/lib/rack/tracker/google_adwords_conversion/template/google_adwords_conversion.erb
+++ b/lib/rack/tracker/google_adwords_conversion/template/google_adwords_conversion.erb
@@ -2,8 +2,8 @@
 
   <script type="text/javascript">
   /* <![CDATA[ */
-  <% ev.to_h.each do |attr_name, attr_value| %>
-    var google_conversion_<%= attr_name %> = <%= attr_name == :id ? attr_value : "'#{attr_value}'" %>;
+  <% options.merge(ev.to_h).each do |attr_name, attr_value| %>
+    var google_conversion_<%= attr_name %> = <%= [:id, :value].include?(attr_name) ? attr_value : "'#{attr_value}'" %>;
   <% end %>
   var google_remarketing_only = false;
   /* ]]> */
@@ -11,7 +11,7 @@
   <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js"></script>
   <noscript>
     <div style="display:inline;">
-      <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/<%= ev.id %>/?label=<%= URI.escape(ev.label) %>&amp;guid=ON&amp;script=0"/>
+      <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/<%= ev.id || options[:id] %>/?label=<%= URI.escape(ev.label || options[:label]) %>&amp;guid=ON&amp;script=0"/>
     </div>
   </noscript>
 

--- a/spec/handler/google_adwords_conversion_spec.rb
+++ b/spec/handler/google_adwords_conversion_spec.rb
@@ -35,4 +35,34 @@ RSpec.describe Rack::Tracker::GoogleAdwordsConversion do
     end
   end
 
+  describe 'with options' do
+    context 'when there are no params for the handler' do
+      let(:options) { { id: 123456,
+                        language: 'en',
+                        format: '3',
+                        color: 'ffffff',
+                        label: 'Conversion Label' } }
+      let(:env) do
+        {
+          'tracker' => {
+            'google_adwords_conversion' => [
+              { 'class_name' => 'Conversion', 'value' => '10.0' }
+            ]
+          }
+        }
+      end
+
+      subject { described_class.new(env, options).render }
+
+      it 'will show events by using default options' do
+        expect(subject).to match(%r{var google_conversion_id = 123456;})
+        expect(subject).to match(%r{var google_conversion_language = 'en';})
+        expect(subject).to match(%r{var google_conversion_format = '3';})
+        expect(subject).to match(%r{var google_conversion_color = 'ffffff';})
+        expect(subject).to match(%r{var google_conversion_label = 'Conversion Label';})
+        expect(subject).to match(%r{var google_conversion_value = 10.0;})
+        expect(subject).to match(%r{<img.*src=\"\/\/www.googleadservices.com\/pagead\/conversion\/123456\/\?label=Conversion%20Label&amp;guid=ON&amp;script=0\"/>})
+      end
+    end
+  end
 end


### PR DESCRIPTION
We'd like to be able to use options configured in our middleware for GAC
as default when we don't specify them on our controllers.
```ruby
# config/application.rb
config.middleware.use(Rack::Tracker) do
  handler :google_analytics, { ecommerce: true, tracker: 'UA-XXXXXXX-X' }
  handler :google_adwords_conversion, { id: 123456,
                                        language: "en",
                                        format: "3",
                                        color: "ffffff",
                                        label: "Conversion Label",
                                        currency: "USD" }
end

# app/controllers/checkouts_controller.rb
def show
  tracker do |t|
    t.google_adwords_conversion :conversion, { value: @order.cost }
  end
end
```