### PR TITLE
Fix Google Analytics pageview command arguments

### DIFF
--- a/lib/rack/tracker/google_analytics/template/google_analytics.erb
+++ b/lib/rack/tracker/google_analytics/template/google_analytics.erb
@@ -36,6 +36,6 @@
   ga('ecommerce:send');
 <% end %>
 <% if tracker %>
-  ga('send', 'pageview', {'location': window.location.href});
+  ga('send', 'pageview', window.location.pathname + window.location.search);
 <% end %>
 </script>

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
 
     it "will show asyncronous tracker with cookieDomain" do
       expect(subject).to match(%r{ga\('create', 'somebody', {\"cookieDomain\":\"railslabs.com\"}\)})
-      expect(subject).to match(%r{ga\('send', 'pageview', {'location': window.location.href}\)})
+      expect(subject).to match(%r{ga\('send', 'pageview', window\.location\.pathname \+ window\.location\.search\)})
     end
   end
 
@@ -203,7 +203,7 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
 
     it "will show asyncronous tracker with userId" do
       expect(subject).to match(%r{ga\('create', 'somebody', {\"userId\":\"123\"}\)})
-      expect(subject).to match(%r{ga\('send', 'pageview', {'location': window.location.href}\)})
+      expect(subject).to match(%r{ga\('send', 'pageview', window\.location\.pathname \+ window\.location\.search\)})
     end
   end
 


### PR DESCRIPTION
I made a mistake in my previous pull request (#40) and should not have used `{ location: '…' }`. We should be using a third `String` parameter instead, according to [this documentation article](https://developers.google.com/analytics/devguides/collection/analyticsjs/pages#overriding).

Sorry about that!