### PR TITLE
set zanox path extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,15 +402,12 @@ window._zx.push({"id": "25GHTE9A07DF67DFG90T"});
 
 #### Conversion tracking
 
-Lead events and sale events use similar text snippets, but different url paths. For example:
-`https://foo.zanox.com/abc/?123456789`, where `abc` is the changing url path. This can be set dynamically along with the rest of the parameters by setting the `path_extension`. 
-
 This is an example of a lead event:
 
 ```
 def show
   tracker do |t|
-    t.zanox :track, { order_i_d: 'DEFC-4321', path_extension: 'abc' }
+    t.zanox :lead, { order_i_d: 'DEFC-4321' }
   end
 end
 ```
@@ -420,7 +417,7 @@ This is an example of a sale event:
 ```
 def show
   tracker do |t|
-    t.zanox :track, { customer_i_d: '123456', order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00', path_extension: 'def'}
+    t.zanox :sale, { customer_i_d: '123456', order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00' }
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -402,12 +402,15 @@ window._zx.push({"id": "25GHTE9A07DF67DFG90T"});
 
 #### Conversion tracking
 
+Lead events and sale events use similar text snippets, but different url paths. For example:
+`https://foo.zanox.com/abc/?123456789`, where `abc` is the changing url path. This can be set dynamically along with the rest of the parameters by setting the `path_extension`. 
+
 This is an example of a lead event:
 
 ```
 def show
   tracker do |t|
-    t.zanox :track, { order_i_d: 'DEFC-4321'}
+    t.zanox :track, { order_i_d: 'DEFC-4321', path_extension: 'abc' }
   end
 end
 ```
@@ -417,7 +420,7 @@ This is an example of a sale event:
 ```
 def show
   tracker do |t|
-    t.zanox :track, { customer_i_d: '123456', order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00'}
+    t.zanox :track, { customer_i_d: '123456', order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00', path_extension: 'def'}
   end
 end
 ```

--- a/lib/rack/tracker/zanox/template/zanox.erb
+++ b/lib/rack/tracker/zanox/template/zanox.erb
@@ -16,11 +16,11 @@
 
 <% tracking_events.each do |event| %>
 
-<script type="text/javascript" src="https://ad.zanox.com/<%= event.set_path_extension %>/?<%= options[:account_id] %>&mode=[[1]]&<%= event.write %>">
+<script type="text/javascript" src="https://ad.zanox.com/<%= event.path_extension %>/?<%= options[:account_id] %>&mode=[[1]]&<%= event.write %>">
 </script>
 
 <noscript>
-<img src="https://ad.zanox.com/<%= event.set_path_extension %>/?<%= options[:account_id] %>&mode=[[2]]&<%= event.write %>" width="1" height="1" />
+<img src="https://ad.zanox.com/<%= event.path_extension %>/?<%= options[:account_id] %>&mode=[[2]]&<%= event.write %>" width="1" height="1" />
 </noscript>
 
 <% end %>

--- a/lib/rack/tracker/zanox/template/zanox.erb
+++ b/lib/rack/tracker/zanox/template/zanox.erb
@@ -14,13 +14,27 @@
 
 <% end %>
 
-<% tracking_events.each do |event| %>
 
-<script type="text/javascript" src="https://ad.zanox.com/<%= event.path_extension %>/?<%= options[:account_id] %>&mode=[[1]]&<%= event.write %>">
-</script>
+<% sale_events.each do |event| %>
 
-<noscript>
-<img src="https://ad.zanox.com/<%= event.path_extension %>/?<%= options[:account_id] %>&mode=[[2]]&<%= event.write %>" width="1" height="1" />
-</noscript>
+  <script type="text/javascript" src="https://ad.zanox.com/pps/?<%= options[:account_id] %>&mode=[[1]]&<%= event.write %>">
+  </script>
+
+  <noscript>
+  <img src="https://ad.zanox.com/pps/?<%= options[:account_id] %>&mode=[[2]]&<%= event.write %>" width="1" height="1" />
+  </noscript>
 
 <% end %>
+
+
+<% lead_events.each do |event| %>
+
+  <script type="text/javascript" src="https://ad.zanox.com/ppl/?<%= options[:account_id] %>&mode=[[1]]&<%= event.write %>">
+  </script>
+
+  <noscript>
+  <img src="https://ad.zanox.com/ppl/?<%= options[:account_id] %>&mode=[[2]]&<%= event.write %>" width="1" height="1" />
+  </noscript>
+
+<% end %>
+

--- a/lib/rack/tracker/zanox/template/zanox.erb
+++ b/lib/rack/tracker/zanox/template/zanox.erb
@@ -16,11 +16,11 @@
 
 <% tracking_events.each do |event| %>
 
-<script type="text/javascript" src="https://ad.zanox.com/ppl/?<%= options[:account_id] %>&mode=[[1]]&<%= event.write %>">
+<script type="text/javascript" src="https://ad.zanox.com/<%= event.set_path_extension %>/?<%= options[:account_id] %>&mode=[[1]]&<%= event.write %>">
 </script>
 
 <noscript>
-<img src="https://ad.zanox.com/ppl/?<%= options[:account_id] %>&mode=[[2]]&<%= event.write %>" width="1" height="1" />
+<img src="https://ad.zanox.com/<%= event.set_path_extension %>/?<%= options[:account_id] %>&mode=[[2]]&<%= event.write %>" width="1" height="1" />
 </noscript>
 
 <% end %>

--- a/lib/rack/tracker/zanox/zanox.rb
+++ b/lib/rack/tracker/zanox/zanox.rb
@@ -7,10 +7,16 @@ class Rack::Tracker::Zanox < Rack::Tracker::Handler
 
   class Track < OpenStruct
     # Example: OrderID=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[23.40]]
+    # url_param gets passed into the url, but should not be one of main parameters set to zanox
     def write
-      to_h.map do |k,v|
+      events = to_h.delete_if { |k,v| k == :path_extension}
+      events.map do |k,v|
         "#{k.to_s.camelize}=[[#{v}]]"
       end.join('&')
+    end
+
+    def set_path_extension
+      to_h[:path_extension]
     end
   end
 

--- a/lib/rack/tracker/zanox/zanox.rb
+++ b/lib/rack/tracker/zanox/zanox.rb
@@ -15,7 +15,7 @@ class Rack::Tracker::Zanox < Rack::Tracker::Handler
       end.join('&')
     end
 
-    def set_path_extension
+    def path_extension
       to_h[:path_extension]
     end
   end

--- a/lib/rack/tracker/zanox/zanox.rb
+++ b/lib/rack/tracker/zanox/zanox.rb
@@ -5,18 +5,21 @@ class Rack::Tracker::Zanox < Rack::Tracker::Handler
   class Mastertag < OpenStruct
   end
 
-  class Track < OpenStruct
+  class Lead < OpenStruct
     # Example: OrderID=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[23.40]]
-    # url_param gets passed into the url, but should not be one of main parameters set to zanox
+
     def write
-      events = to_h.delete_if { |k,v| k == :path_extension}
-      events.map do |k,v|
+      to_h.map do |k,v|
         "#{k.to_s.camelize}=[[#{v}]]"
       end.join('&')
     end
+  end
 
-    def path_extension
-      to_h[:path_extension]
+  class Sale < OpenStruct
+    def write
+      to_h.map do |k,v|
+        "#{k.to_s.camelize}=[[#{v}]]"
+      end.join('&')
     end
   end
 
@@ -28,8 +31,12 @@ class Rack::Tracker::Zanox < Rack::Tracker::Handler
     events.select{ |event| event.class.to_s.demodulize == 'Mastertag' }.first
   end
 
-  def tracking_events
-    events.select{ |event| event.class.to_s.demodulize == 'Track' }
+  def lead_events
+    events.select{ |event| event.class.to_s.demodulize == 'Lead' }
+  end
+
+  def sale_events
+    events.select{ |event| event.class.to_s.demodulize == 'Sale' }
   end
 
   def render

--- a/spec/handler/zanox_spec.rb
+++ b/spec/handler/zanox_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Rack::Tracker::Zanox do
 
-  describe Rack::Tracker::Zanox::Track do
+  describe Rack::Tracker::Zanox::Sale do
 
-    subject { described_class.new(order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00', path_extension: 'zan') }
+    subject { described_class.new(order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00') }
 
     describe '#write' do
       specify { expect(subject.write).to eq "OrderID=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[150.00]]" }
@@ -18,7 +18,7 @@ RSpec.describe Rack::Tracker::Zanox do
     expect(described_class.new(env).position).to eq(:body)
   end
 
-  describe '#render a sale #tracking_event' do
+  describe '#render #sale_events' do
     context 'with events' do
       let(:env) {
         {
@@ -30,8 +30,7 @@ RSpec.describe Rack::Tracker::Zanox do
                 'OrderId' => 'DEFC-4321',
                 'CurrencySymbol' => 'EUR',
                 'TotalPrice' => '150.00',
-                'class_name' => 'Track',
-                'path_extension' => 'zan'
+                'class_name' => 'Sale',
               }
             ]
           }
@@ -42,12 +41,12 @@ RSpec.describe Rack::Tracker::Zanox do
       let(:options) { { account_id: '123456H123456' } }
 
       it 'will display the correct tracking events' do
-        expect(subject).to include "https://ad.zanox.com/zan/?123456H123456&mode=[[1]]&CustomerID=[[123456]]&OrderId=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[150.00]]"
+        expect(subject).to include "https://ad.zanox.com/pps/?123456H123456&mode=[[1]]&CustomerID=[[123456]]&OrderId=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[150.00]]"
       end
     end
   end
 
-  describe '#render a lead #tracking_event' do
+  describe '#render #lead_events' do
     context 'with events' do
       let(:env) {
         {
@@ -56,8 +55,7 @@ RSpec.describe Rack::Tracker::Zanox do
             [
               {
                 'OrderId' => 'DEFC-4321',
-                'class_name' => 'Track',
-                'path_extension' => 'fan'
+                'class_name' => 'Lead'
               }
             ]
           }
@@ -68,7 +66,7 @@ RSpec.describe Rack::Tracker::Zanox do
       let(:options) { { account_id: '123456H123456' } }
 
       it 'will display the correct tracking events' do
-        expect(subject).to include "https://ad.zanox.com/fan/?123456H123456&mode=[[1]]&OrderId=[[DEFC-4321]]"
+        expect(subject).to include "https://ad.zanox.com/ppl/?123456H123456&mode=[[1]]&OrderId=[[DEFC-4321]]"
       end
     end
   end

--- a/spec/handler/zanox_spec.rb
+++ b/spec/handler/zanox_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Rack::Tracker::Zanox do
 
   describe Rack::Tracker::Zanox::Track do
 
-    subject { described_class.new(order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00') }
+    subject { described_class.new(order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00', path_extension: 'zan') }
 
     describe '#write' do
       specify { expect(subject.write).to eq "OrderID=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[150.00]]" }
@@ -30,7 +30,8 @@ RSpec.describe Rack::Tracker::Zanox do
                 'OrderId' => 'DEFC-4321',
                 'CurrencySymbol' => 'EUR',
                 'TotalPrice' => '150.00',
-                'class_name' => 'Track'
+                'class_name' => 'Track',
+                'path_extension' => 'zan'
               }
             ]
           }
@@ -41,7 +42,7 @@ RSpec.describe Rack::Tracker::Zanox do
       let(:options) { { account_id: '123456H123456' } }
 
       it 'will display the correct tracking events' do
-        expect(subject).to include "https://ad.zanox.com/ppl/?123456H123456&mode=[[1]]&CustomerID=[[123456]]&OrderId=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[150.00]]"
+        expect(subject).to include "https://ad.zanox.com/zan/?123456H123456&mode=[[1]]&CustomerID=[[123456]]&OrderId=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[150.00]]"
       end
     end
   end
@@ -55,7 +56,8 @@ RSpec.describe Rack::Tracker::Zanox do
             [
               {
                 'OrderId' => 'DEFC-4321',
-                'class_name' => 'Track'
+                'class_name' => 'Track',
+                'path_extension' => 'fan'
               }
             ]
           }
@@ -66,7 +68,7 @@ RSpec.describe Rack::Tracker::Zanox do
       let(:options) { { account_id: '123456H123456' } }
 
       it 'will display the correct tracking events' do
-        expect(subject).to include "https://ad.zanox.com/ppl/?123456H123456&mode=[[1]]&OrderId=[[DEFC-4321]]"
+        expect(subject).to include "https://ad.zanox.com/fan/?123456H123456&mode=[[1]]&OrderId=[[DEFC-4321]]"
       end
     end
   end

--- a/spec/integration/zanox_integration_spec.rb
+++ b/spec/integration/zanox_integration_spec.rb
@@ -17,9 +17,6 @@ RSpec.describe "Zanox Integration" do
   end
 
   it 'should include the track event' do
-    expect(page).to have_xpath "//script[contains(@src,'12345H123456789&mode=[[1]]&CustomerID=[[123456]]&OrderID=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[150.00]]')]"
+    expect(page).to have_xpath "//script[contains(@src,'zan/?12345H123456789&mode=[[1]]&CustomerID=[[123456]]&OrderID=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[150.00]]')]"
   end
 end
-
-
-

--- a/spec/integration/zanox_integration_spec.rb
+++ b/spec/integration/zanox_integration_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe "Zanox Integration" do
     expect(page.find("body")).to have_content "window._zx.push({\"id\": \"blurg567\"});"
   end
 
-  it 'should include the track event' do
-    expect(page).to have_xpath "//script[contains(@src,'zan/?12345H123456789&mode=[[1]]&CustomerID=[[123456]]&OrderID=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[150.00]]')]"
+  it 'should include the sale event' do
+    expect(page).to have_xpath "//script[contains(@src,'pps/?12345H123456789&mode=[[1]]&CustomerID=[[123456]]&OrderID=[[DEFC-4321]]&CurrencySymbol=[[EUR]]&TotalPrice=[[150.00]]')]"
+  end
+
+  it 'should include the lead event' do
+    expect(page).to have_xpath "//script[contains(@src,'ppl/?12345H123456789&mode=[[1]]&CustomerID=[[654321]]')]"
   end
 end

--- a/spec/support/metal_controller.rb
+++ b/spec/support/metal_controller.rb
@@ -78,7 +78,7 @@ class MetalController < ActionController::Metal
   def zanox
     tracker do |t|
       t.zanox :mastertag, { id: 'blurg567'}
-      t.zanox :track, { customer_i_d: '123456', order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00'}
+      t.zanox :track, { customer_i_d: '123456', order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00', path_extension: 'zan'}
     end
     render 'metal/index'
   end

--- a/spec/support/metal_controller.rb
+++ b/spec/support/metal_controller.rb
@@ -78,7 +78,8 @@ class MetalController < ActionController::Metal
   def zanox
     tracker do |t|
       t.zanox :mastertag, { id: 'blurg567'}
-      t.zanox :track, { customer_i_d: '123456', order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00', path_extension: 'zan'}
+      t.zanox :sale, { customer_i_d: '123456', order_i_d: 'DEFC-4321', currency_symbol: 'EUR', total_price: '150.00' }
+      t.zanox :lead, { customer_i_d: '654321' }
     end
     render 'metal/index'
   end


### PR DESCRIPTION
Zanox has alerted me to the fact that our url path was set up wrong. This PR fixes that. Whereas before the path in the template was set as, for example, 
`https://ad.zanox.com/abc` and could not be changed, now the `abc` can be set dynamically by passing in a parameter along w/ the rest of them. 

let me know if there's any questions/concerns!