### PR TITLE
Fix for #50, prevent messed html when one or more literal `\` are pre…

### DIFF
--- a/lib/rack/tracker.rb
+++ b/lib/rack/tracker.rb
@@ -56,7 +56,12 @@ module Rack
 
     def inject(env, response)
       @handlers.each(env) do |handler|
-        response.gsub!(%r{</#{handler.position}>}, handler.render + "</#{handler.position}>")
+        # Sub! is enough, in well formed html there's only one head or body tag.
+        # Block syntax need to be used, otherwise backslashes in input will mess the output.
+        # @see http://stackoverflow.com/a/4149087/518204 and https://github.com/railslove/rack-tracker/issues/50
+        response.sub! %r{</#{handler.position}>} do |m|
+          handler.render << m.to_s
+        end
       end
       response
     end

--- a/spec/integration/google_analytics_integration_spec.rb
+++ b/spec/integration/google_analytics_integration_spec.rb
@@ -29,4 +29,18 @@ RSpec.describe "Google Analytics Integration" do
      expect(page.find("body")).to have_content('ga("ecommerce:addItem",{"id":"1234","name":"Fluffy Pink Bunnies","sku":"DD23444","category":"Party Toys","price":"11.99","quantity":"1"})')
     end
   end
+
+  describe 'values escaping' do
+    before do
+      setup_app(action: :google_analytics) do |tracker|
+        tracker.handler :google_analytics, { tracker: 'U-XXX-Y' }
+      end
+      visit '/'
+    end
+
+    it "will not mess up the html" do
+      expect(page.find('head')).to have_content('U-XXX-Y')
+      expect(page.find('head')).to have_content %q{Some escaped \\'value}
+    end
+  end
 end

--- a/spec/support/metal_controller.rb
+++ b/spec/support/metal_controller.rb
@@ -34,6 +34,7 @@ class MetalController < ActionController::Metal
       t.google_analytics :ecommerce, { type: 'addTransaction', id: 1234, affiliation: 'Acme Clothing', revenue: 11.99, shipping: 5, tax: 1.29 }
       t.google_analytics :ecommerce, { type: 'addItem', id: 1234, name: 'Fluffy Pink Bunnies', sku: 'DD23444', category: 'Party Toys', price: 11.99, quantity: 1 }
       t.google_analytics :send, { type: 'event', category: 'button', action: 'click', label: 'nav-buttons', value: 'X' }
+      t.google_analytics :parameter, dimension1: %q{Some escaped \\'value}
     end
     render "metal/index"
   end


### PR DESCRIPTION
…sent in rendered trackers.