### PR TITLE
Javascript escape implementation to prevent XSS

### DIFF
--- a/lib/rack/tracker.rb
+++ b/lib/rack/tracker.rb
@@ -7,6 +7,7 @@ require "active_support/inflector"
 
 require "rack/tracker/version"
 require "rack/tracker/extensions"
+require "rack/tracker/javascript_helper"
 require 'rack/tracker/railtie' if defined?(Rails)
 require "rack/tracker/handler"
 require "rack/tracker/handler_delegator"

--- a/lib/rack/tracker.rb
+++ b/lib/rack/tracker.rb
@@ -56,7 +56,12 @@ module Rack
 
     def inject(env, response)
       @handlers.each(env) do |handler|
-        response.gsub!(%r{</#{handler.position}>}, handler.render + "</#{handler.position}>")
+        # Sub! is enough, in well formed html there's only one head or body tag.
+        # Block syntax need to be used, otherwise backslashes in input will mess the output.
+        # @see http://stackoverflow.com/a/4149087/518204 and https://github.com/railslove/rack-tracker/issues/50
+        response.sub! %r{</#{handler.position}>} do |m|
+          handler.render << m.to_s
+        end
       end
       response
     end

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -47,8 +47,9 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
   end
 
   class Parameter < OpenStruct
+    include Rack::Tracker::JavaScriptHelper
     def write
-      ["set", self.to_h.to_a].flatten.map {|s| "'#{s}'" }.join(', ')
+      ['set', self.to_h.to_a].flatten.map { |v| %Q{'#{j(v)}'} }.join ', '
     end
   end
 

--- a/lib/rack/tracker/handler.rb
+++ b/lib/rack/tracker/handler.rb
@@ -5,6 +5,9 @@ class Rack::Tracker::Handler
   attr_accessor :options
   attr_accessor :env
 
+  # Allow javascript escaping in view templates
+  include Rack::Tracker::JavaScriptHelper
+
   def initialize(env, options = {})
     self.env = env
     self.options  = options

--- a/lib/rack/tracker/javascript_helper.rb
+++ b/lib/rack/tracker/javascript_helper.rb
@@ -24,7 +24,7 @@ module Rack::Tracker::JavaScriptHelper
   #   $('some_element').replaceWith('<%=j render 'some/element_template' %>');
   def escape_javascript(javascript)
     if javascript
-      javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"'])/u) { |match| JS_ESCAPE_MAP[match] }
+      javascript.to_s.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"'])/u) { |match| JS_ESCAPE_MAP[match] }
     else
       ''
     end

--- a/lib/rack/tracker/javascript_helper.rb
+++ b/lib/rack/tracker/javascript_helper.rb
@@ -1,0 +1,34 @@
+# This module is extracted from Rails to provide reliable javascript escaping.
+#
+# @see https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/javascript_helper.rb
+module Rack::Tracker::JavaScriptHelper
+
+  JS_ESCAPE_MAP = {
+      '\\' => '\\\\',
+      '</' => '<\/',
+      "\r\n" => '\n',
+      "\n" => '\n',
+      "\r" => '\n',
+      '"' => '\\"',
+      "'" => "\\'"
+  }
+
+  JS_ESCAPE_MAP["\342\200\250".force_encoding(Encoding::UTF_8).encode!] = '&#x2028;'
+  JS_ESCAPE_MAP["\342\200\251".force_encoding(Encoding::UTF_8).encode!] = '&#x2029;'
+
+  # Escapes carriage returns and single and double quotes for JavaScript segments.
+  #
+  # Also available through the alias j(). This is particularly helpful in JavaScript
+  # responses, like:
+  #
+  #   $('some_element').replaceWith('<%=j render 'some/element_template' %>');
+  def escape_javascript(javascript)
+    if javascript
+      javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"'])/u) { |match| JS_ESCAPE_MAP[match] }
+    else
+      ''
+    end
+  end
+
+  alias_method :j, :escape_javascript
+end

--- a/spec/integration/google_analytics_integration_spec.rb
+++ b/spec/integration/google_analytics_integration_spec.rb
@@ -29,4 +29,18 @@ RSpec.describe "Google Analytics Integration" do
      expect(page.find("body")).to have_content('ga("ecommerce:addItem",{"id":"1234","name":"Fluffy Pink Bunnies","sku":"DD23444","category":"Party Toys","price":"11.99","quantity":"1"})')
     end
   end
+
+  describe 'values escaping' do
+    before do
+      setup_app(action: :google_analytics) do |tracker|
+        tracker.handler :google_analytics, { tracker: 'U-XXX-Y' }
+      end
+      visit '/'
+    end
+
+    it "will not mess up the html" do
+      expect(page.find('head')).to have_content('U-XXX-Y')
+      expect(page.find('head')).to have_content %q{Some escaped \\'value}
+    end
+  end
 end

--- a/spec/integration/google_analytics_integration_spec.rb
+++ b/spec/integration/google_analytics_integration_spec.rb
@@ -40,7 +40,13 @@ RSpec.describe "Google Analytics Integration" do
 
     it "will not mess up the html" do
       expect(page.find('head')).to have_content('U-XXX-Y')
-      expect(page.find('head')).to have_content %q{Some escaped \\'value}
+      # Backslashes are also escaped, thus \' becomes in \\\' in output
+      expect(page.find('head')).to have_content %q{Some escaped \\\\\\'value}
+    end
+
+    it "automatically escape javascript in dimensions" do
+      expect(page.find('head')).to have_content('U-XXX-Y')
+      expect(page.find('head')).to have_content %q{Author\\'s name}
     end
   end
 end

--- a/spec/support/metal_controller.rb
+++ b/spec/support/metal_controller.rb
@@ -35,6 +35,7 @@ class MetalController < ActionController::Metal
       t.google_analytics :ecommerce, { type: 'addItem', id: 1234, name: 'Fluffy Pink Bunnies', sku: 'DD23444', category: 'Party Toys', price: 11.99, quantity: 1 }
       t.google_analytics :send, { type: 'event', category: 'button', action: 'click', label: 'nav-buttons', value: 'X' }
       t.google_analytics :parameter, dimension1: %q{Some escaped \\'value}
+      t.google_analytics :parameter, dimension2: %q{Author's name}
     end
     render "metal/index"
   end

--- a/spec/support/metal_controller.rb
+++ b/spec/support/metal_controller.rb
@@ -34,6 +34,7 @@ class MetalController < ActionController::Metal
       t.google_analytics :ecommerce, { type: 'addTransaction', id: 1234, affiliation: 'Acme Clothing', revenue: 11.99, shipping: 5, tax: 1.29 }
       t.google_analytics :ecommerce, { type: 'addItem', id: 1234, name: 'Fluffy Pink Bunnies', sku: 'DD23444', category: 'Party Toys', price: 11.99, quantity: 1 }
       t.google_analytics :send, { type: 'event', category: 'button', action: 'click', label: 'nav-buttons', value: 'X' }
+      t.google_analytics :parameter, dimension1: %q{Some escaped \\'value}
     end
     render "metal/index"
   end

--- a/spec/tracker/javascript_helper_spec.rb
+++ b/spec/tracker/javascript_helper_spec.rb
@@ -42,6 +42,10 @@ RSpec.describe Rack::Tracker do
     it { should escape(%(unicode \342\200\250 newline).force_encoding(Encoding::UTF_8).encode!).to %(unicode &#x2028; newline) }
     it { should escape(%(unicode \342\200\251 newline).force_encoding(Encoding::UTF_8).encode!).to %(unicode &#x2029; newline) }
 
+    it 'works with symbols' do
+      expect(subject).to escape(:dimension1).to 'dimension1'
+    end
+
   end
 
 end

--- a/spec/tracker/javascript_helper_spec.rb
+++ b/spec/tracker/javascript_helper_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Rack::Tracker do
+
+  let(:escaper) do
+    Class.new { include Rack::Tracker::JavaScriptHelper }.new
+  end
+
+  subject { escaper }
+
+  # Instance methods are mixed in
+  it { should respond_to :escape_javascript }
+  it { should respond_to :j }
+
+  context 'with plain values' do
+    it 'should return untouched values' do
+      expect(escaper.j('Hello')).to eq 'Hello'
+    end
+  end
+
+  # The following is a RSpec port of original rails's test suite for #j method.
+  # https://github.com/rails/rails/blob/master/actionview/test/template/javascript_helper_test.rb
+  describe '#escape_javascript' do
+
+    # Simple matcher to shorten specs
+    matcher :escape do |value|
+
+      match do |actual|
+        raise ArgumentError, 'macther syntax is escape("some value").to("expected value")' unless @expected
+        actual.j(value) == @expected
+      end
+
+      # Syntactic sugar for matcher
+      chain :to do |to|
+        @expected = to
+        self
+      end
+    end
+
+    it { should escape(nil).to '' }
+    it { should escape(%(This "thing" is really\n netos')).to %(This \\"thing\\" is really\\n netos\\') }
+    it { should escape(%(backslash\\test)).to %(backslash\\\\test) }
+    it { should escape(%(dont </close> tags)).to %(dont <\\/close> tags) }
+    it { should escape(%(unicode \342\200\250 newline).force_encoding(Encoding::UTF_8).encode!).to %(unicode &#x2028; newline) }
+    it { should escape(%(unicode \342\200\251 newline).force_encoding(Encoding::UTF_8).encode!).to %(unicode &#x2029; newline) }
+
+  end
+
+end


### PR DESCRIPTION
I've started the implementation of a javascript escaper module took from rails code.

I've currently only implemented

* The helper itself (took from rails)
* Mixed in the helper to allow usage in erb templates
* Created a failing spec for an analytic dimension and a patch to fix it

What is still missing is to review all trackers and escape where potentially untrusted input is written.

I think this should be enough to start with.

Let me know what do you think.