### PR TITLE
Update Facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,16 +254,26 @@ To add events or variables to the dataLayer from the server side, just call the 
 
 ### Facebook
 
-* `custom_audience` - adds the [Custom audience](https://developers.facebook.com/docs/reference/ads-api/custom-audience-website-faq) segmentation pixel
+* `Facebook Pixel` - adds the [Facebook Pixel](https://www.facebook.com/business/help/952192354843755)
 
-#### Conversions
+Use in conjunction with the [Facebook Helper](https://developers.facebook.com/docs/facebook-pixel/pixel-helper) to confirm your event fires correctly.
 
-To track [Conversions](https://www.facebook.com/help/435189689870514) from the server side just call the `tracker` method in your controller.
+First, add the following to your config:
+
+```ruby
+  config.middleware.use(Rack::Tracker) do
+    handler :facebook, { id: 'PIXEL_ID' }
+  end
+```
+
+#### Standard Events
+
+To track Standard Events from the server side just call the `tracker` method in your controller.
 
 ```ruby
   def show
     tracker do |t|
-      t.facebook :track, { id: '123456789', value: 1, currency: 'EUR' }
+      t.facebook :track, { type: 'Purchase', options: { value: 100, currency: 'USD' } }
     end
   end
 ```
@@ -271,8 +281,9 @@ To track [Conversions](https://www.facebook.com/help/435189689870514) from the s
 Will result in the following:
 
 ```javascript
-  window._fbq.push(["track", "123456789", {'value': 1, 'currency': 'EUR'}]);
+  fbq("track", "Purchase", {"value":"100.0","currency":"USD"});
 ```
+
 ### Visual website Optimizer (VWO)
 Just integrate the handler with your matching account_id and you will be ready to go
 

--- a/lib/rack/tracker/facebook/facebook.rb
+++ b/lib/rack/tracker/facebook/facebook.rb
@@ -11,7 +11,7 @@ class Rack::Tracker::Facebook < Rack::Tracker::Handler
     end
 
     def options_to_json
-      return nil if self.options.empty?
+      return nil unless self.options.present?
 
       self.options.to_json
     end

--- a/lib/rack/tracker/facebook/facebook.rb
+++ b/lib/rack/tracker/facebook/facebook.rb
@@ -1,7 +1,19 @@
 class Rack::Tracker::Facebook < Rack::Tracker::Handler
   class Event < OpenStruct
     def write
-      ['track', self.id, to_h.except(:id).compact].to_json
+      [type_to_json, options_to_json].compact.join(', ')
+    end
+
+    private
+
+    def type_to_json
+      self.type.to_json
+    end
+
+    def options_to_json
+      return nil if self.options.empty?
+
+      self.options.to_json
     end
   end
 
@@ -14,5 +26,4 @@ class Rack::Tracker::Facebook < Rack::Tracker::Handler
   def self.track(name, *event)
     { name.to_s => [event.last.merge('class_name' => 'Event')] }
   end
-
 end

--- a/lib/rack/tracker/facebook/template/facebook.erb
+++ b/lib/rack/tracker/facebook/template/facebook.erb
@@ -1,40 +1,20 @@
 <script type="text/javascript">
-  (function() {
-    var _fbq = window._fbq || (window._fbq = []);
-    if (!_fbq.loaded) {
-      var fbds = document.createElement('script');
-      fbds.async = true;
-      fbds.src = '//connect.facebook.net/en_US/fbds.js';
-      var s = document.getElementsByTagName('script')[0];
-      s.parentNode.insertBefore(fbds, s);
-      _fbq.loaded = true;
-    }
-  })();
-  window._fbq = window._fbq || [];
-
+  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+  document,'script','//connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '<%= options[:id] %>');
+  fbq('track', "PageView");
 </script>
-
-<% if options[:custom_audience] %>
-<script type="text/javascript">
-window._fbq.push(["addPixelId", "<%= options[:custom_audience] %>"]);
-window._fbq.push(["track", "PixelInitialized", {}]);
-</script>
-
 <noscript>
-  <img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?id=<%= options[:custom_audience] %>&amp;ev=PixelInitialized">
+  <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=<%= options[:id] %>&ev=PageView&noscript=1"/>
 </noscript>
-<% end %>
 
 <% if events.any? %>
-<script type="text/javascript">
-<% events.each do |event| %>
-window._fbq.push(<%= event.write %>);
-<% end %>
-</script>
-
-<noscript>
-  <% events.each do |event| %>
-  <img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/offsite_event.php?id=<%= event.id %>&amp;value=<%= event.value %>&amp;currency=<%= event.currency %>">
-  <% end %>
-</noscript>
+  <script type="text/javascript">
+    <% events.each do |event| %>
+      fbq("track", <%= event.write %>);
+    <% end %>
+  </script>
 <% end %>


### PR DESCRIPTION
Updated to use the new Facebook pixel. Not sure if this should replace the current Facebook (obviously not backward-compatible), maybe I should pull it out into a new module. Also playing with adding a method to `application_controller` to make tracking even easier:

``` ruby
def track_facebook_event(type, options={})
  tracker do |t|
    t.facebook :track, { type: type, options: options}
  end
end
```

Also updated the README with some examples of how it works. 
I'm happy to continue updating this as necessary, let me know if there are any changes you would like to see.

edit: lol forgot the specs. well, let me know if this is useful before I change them  ¯\_(ツ)_/¯
