### PR TITLE
Fix for Rails 5 env deprecation warning

### DIFF
--- a/lib/rack/tracker/controller.rb
+++ b/lib/rack/tracker/controller.rb
@@ -3,7 +3,7 @@ module Rack
     module Controller
       def tracker(&block)
         if block_given?
-          yield(Rack::Tracker::HandlerDelegator.new(env))
+          yield(Rack::Tracker::HandlerDelegator.new(request.env))
         end
       end
     end


### PR DESCRIPTION
DEPRECATION WARNING: env is deprecated and will be removed from Rails 5.1
