### PR TITLE
The dataLayer.push needs to occur before the container snippet

### DIFF
--- a/lib/rack/tracker/google_tag_manager/template/google_tag_manager.erb
+++ b/lib/rack/tracker/google_tag_manager/template/google_tag_manager.erb
@@ -3,6 +3,12 @@
   dataLayer = [];
 </script>
 
+<script>
+dataLayer.push(
+  <%= events.map(&:write).join(', ') %>
+);
+</script>
+
 <noscript><iframe src="//www.googletagmanager.com/ns.html?id=<%= container %>"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -11,9 +17,4 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','<%= container %>');</script>
 
-<script>
-dataLayer.push(
-  <%= events.map(&:write).join(', ') %>
-);
-</script>
 <% end %>


### PR DESCRIPTION
Variables pushed to the dataLayer after the container snippet are not registered. Moving the container to the last position. 
