### PR TITLE
Allow for dynamic Facebook ID

### DIFF
--- a/lib/rack/tracker/facebook/facebook.rb
+++ b/lib/rack/tracker/facebook/facebook.rb
@@ -11,6 +11,14 @@ class Rack::Tracker::Facebook < Rack::Tracker::Handler
     Tilt.new( File.join( File.dirname(__FILE__), 'template/facebook.erb') ).render(self)
   end
 
+  def custom_audience
+    if options[:custom_audience].respond_to?(:call)
+      options[:custom_audience].call(env)
+    else
+      options[:custom_audience]
+    end
+  end
+
   def self.track(name, *event)
     { name.to_s => [event.last.merge('class_name' => 'Event')] }
   end

--- a/lib/rack/tracker/facebook/template/facebook.erb
+++ b/lib/rack/tracker/facebook/template/facebook.erb
@@ -13,15 +13,14 @@
   window._fbq = window._fbq || [];
 
 </script>
-
-<% if options[:custom_audience] %>
+<% if custom_audience %>
 <script type="text/javascript">
-window._fbq.push(["addPixelId", "<%= options[:custom_audience] %>"]);
+window._fbq.push(["addPixelId", "<%= custom_audience %>"]);
 window._fbq.push(["track", "PixelInitialized", {}]);
 </script>
 
 <noscript>
-  <img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?id=<%= options[:custom_audience] %>&amp;ev=PixelInitialized">
+  <img height="1" width="1" alt="" style="display:none" src="https://www.facebook.com/tr?id=<%= custom_audience %>&amp;ev=PixelInitialized">
 </noscript>
 <% end %>
 


### PR DESCRIPTION
This allows the custom_audience attribute of the Facebook tracker to be
a lambda, and therefore dynamic, mimicking the behaviour of the GA
tracker described in #34.
