### PR TITLE
Fix rails 5 depreciation warning

### DIFF
--- a/lib/rack/tracker/controller.rb
+++ b/lib/rack/tracker/controller.rb
@@ -3,7 +3,7 @@ module Rack
     module Controller
       def tracker(&block)
         if block_given?
-          yield(Rack::Tracker::HandlerDelegator.new(env))
+          yield(Rack::Tracker::HandlerDelegator.new(request.env))
         end
       end
     end


### PR DESCRIPTION
Hi,

This is a just a simple fix to avoid warnings caused by `env` being depreciated in rails 5.1. We now have to access it through the `request` object.

Best regards