### PR TITLE
Fix Travis, pin 1.9 dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,22 @@ sudo: false
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.5
-  - 2.2.3
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
   - jruby
+  - jruby-9.1.5.0
 gemfile:
+  - Gemfile
   - Gemfile.rails-3.2
   - Gemfile.rails-4.2
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      gemfile: Gemfile
+    - rvm: 2.0.0
+      gemfile: Gemfile
+    - rvm: 2.1.9
+      gemfile: Gemfile
+    - rvm: jruby
+      gemfile: Gemfile

--- a/rack-tracker.gemspec
+++ b/rack-tracker.gemspec
@@ -28,4 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "capybara", "~> 2.4"
   spec.add_development_dependency "pry"
+  if RUBY_VERSION < "2.0"
+    spec.add_development_dependency "mime-types", "< 3.0"
+    spec.add_development_dependency "addressable", "< 2.5"
+  end
 end


### PR DESCRIPTION
Updated Travis matrix to exclude Rails 5 on Ruby < 2.2, and pinned the addressable and mime-types gems to compatible versions for Ruby < 2.0. I can alternatively update to drop support for 1.9 altogether - looks like this has been holding up quite a few PRs.