### PR TITLE
Fix google tag manager snippet in wrong position (#80).

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,13 +517,35 @@ found right before `</head>`. You can change the position in your handler-code:
 
 ```ruby
 class MyHandler <  Rack::Tracker::Handler
-  self.position = :body
-
-  ...
+  def default_positions
+    { before_body_close: :render }
+  end
 end
 ```
 
-The snippit will then be rendered right before `</body>`.
+The snippit will then be rendered right before `</body>`. Other options are :after_head_open
+and :after_body_open.
+
+I you need to render snippets in different positions. You can do so like this:
+
+```ruby
+class MyHandler <  Rack::Tracker::Handler
+  def render_head
+    Tilt.new( File.join( File.dirname(__FILE__), 'template', 'my_handler.erb') ).render(self)
+  end
+
+  def render
+    Tilt.new( File.join( File.dirname(__FILE__), 'template', 'my_handler.erb') ).render(self)
+  end
+
+  def default_positions
+    { 
+      before_head_close: :render_head,
+      before_body_open:  :render
+    }
+  end
+end
+```
 
 To enable the *tracker dsl* functionality in your controllers
 you need to implement the `track` class method on your handler:

--- a/lib/rack/tracker/criteo/criteo.rb
+++ b/lib/rack/tracker/criteo/criteo.rb
@@ -13,9 +13,7 @@ class Rack::Tracker::Criteo <  Rack::Tracker::Handler
       to_h.to_json
     end
   end
-
-  self.position = :body
-
+  
   # global events (setSiteType, setAccount, ...) for each tracker instance
   def tracker_events
     @tracker_events ||= [].tap do |tracker_events|
@@ -33,5 +31,9 @@ class Rack::Tracker::Criteo <  Rack::Tracker::Handler
 
   def self.track(name, event_name, event_args = {})
     { name.to_s => [{ 'class_name' => 'Event', 'event' => event_name.to_s.camelize(:lower) }.merge(event_args)] }
+  end
+
+  def default_positions
+    { before_body_close: :render }
   end
 end

--- a/lib/rack/tracker/facebook/facebook.rb
+++ b/lib/rack/tracker/facebook/facebook.rb
@@ -5,8 +5,6 @@ class Rack::Tracker::Facebook < Rack::Tracker::Handler
     end
   end
 
-  self.position = :body
-
   def render
     Tilt.new( File.join( File.dirname(__FILE__), 'template/facebook.erb') ).render(self)
   end
@@ -15,4 +13,7 @@ class Rack::Tracker::Facebook < Rack::Tracker::Handler
     { name.to_s => [event.last.merge('class_name' => 'Event')] }
   end
 
+  def default_positions
+    { before_body_close: :render }
+  end
 end

--- a/lib/rack/tracker/go_squared/go_squared.rb
+++ b/lib/rack/tracker/go_squared/go_squared.rb
@@ -34,4 +34,8 @@ class Rack::Tracker::GoSquared < Rack::Tracker::Handler
   def self.track(name, *event)
     { name.to_s => [event.last.merge('class_name' => event.first.to_s.classify)] }
   end
+
+  def default_positions
+    { before_head_close: :render }
+  end
 end

--- a/lib/rack/tracker/google_adwords_conversion/google_adwords_conversion.rb
+++ b/lib/rack/tracker/google_adwords_conversion/google_adwords_conversion.rb
@@ -3,13 +3,15 @@ class Rack::Tracker::GoogleAdwordsConversion < Rack::Tracker::Handler
   class Conversion < OpenStruct
   end
 
-  self.position = :body
-
   def render
     Tilt.new( File.join( File.dirname(__FILE__), 'template', 'google_adwords_conversion.erb') ).render(self)
   end
 
   def self.track(name, *event)
     { name.to_s => [event.last.merge('class_name' => event.first.to_s.capitalize)] }
+  end
+
+  def default_positions
+    { before_body_close: :render }
   end
 end

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -82,4 +82,8 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
   def self.track(name, *event)
     { name.to_s => [event.last.merge('class_name' => event.first.to_s.classify)] }
   end
+
+  def default_positions
+    { before_head_close: :render }
+  end
 end

--- a/lib/rack/tracker/google_tag_manager/google_tag_manager.rb
+++ b/lib/rack/tracker/google_tag_manager/google_tag_manager.rb
@@ -5,20 +5,27 @@ class Rack::Tracker::GoogleTagManager < Rack::Tracker::Handler
       to_h.to_json
     end
   end
-
-  # It is strongly recommended to put the google_tag_manager snippet only in the body tag
-  # https://developers.google.com/tag-manager/quickstart
-  self.position = :body
-
+  
   def container
     options[:container].respond_to?(:call) ? options[:container].call(env) : options[:container]
   end
 
-  def render
+  def render_head
+    Tilt.new( File.join( File.dirname(__FILE__), 'template', 'google_tag_manager_head.erb') ).render(self)
+  end
+
+  def render_body
     Tilt.new( File.join( File.dirname(__FILE__), 'template', 'google_tag_manager.erb') ).render(self)
   end
 
   def self.track(name, *event)
     { name.to_s => [event.last.merge('class_name' => event.first.to_s.capitalize)] }
+  end
+
+  def default_positions
+    {
+      before_head_close: :render_head,
+      after_body_open: :render_body
+    }
   end
 end

--- a/lib/rack/tracker/google_tag_manager/template/google_tag_manager.erb
+++ b/lib/rack/tracker/google_tag_manager/template/google_tag_manager.erb
@@ -1,19 +1,4 @@
 <% if container %>
-<script>
-  dataLayer = [];
-</script>
-
 <noscript><iframe src="//www.googletagmanager.com/ns.html?id=<%= container %>"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','<%= container %>');</script>
-
-<script>
-dataLayer.push(
-  <%= events.map(&:write).join(', ') %>
-);
-</script>
 <% end %>

--- a/lib/rack/tracker/google_tag_manager/template/google_tag_manager_head.erb
+++ b/lib/rack/tracker/google_tag_manager/template/google_tag_manager_head.erb
@@ -1,0 +1,17 @@
+<% if container %>
+<script>
+  dataLayer = [];
+</script>
+
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','<%= container %>');</script>
+
+<script>
+dataLayer.push(
+  <%= events.map(&:write).join(', ') %>
+);
+</script>
+<% end %>

--- a/lib/rack/tracker/handler.rb
+++ b/lib/rack/tracker/handler.rb
@@ -1,9 +1,7 @@
 class Rack::Tracker::Handler
-  class_attribute :position
-  self.position = :head
-
   attr_accessor :options
   attr_accessor :env
+  attr_accessor :positions
 
   # Allow javascript escaping in view templates
   include Rack::Tracker::JavaScriptHelper
@@ -11,7 +9,7 @@ class Rack::Tracker::Handler
   def initialize(env, options = {})
     self.env = env
     self.options  = options
-    self.position = options[:position] if options.has_key?(:position)
+    self.positions = options[:positions] || default_positions
   end
 
   def events
@@ -25,5 +23,9 @@ class Rack::Tracker::Handler
 
   def self.track(name, event)
     raise NotImplementedError.new("class method `#{__callee__}` is not implemented.")
+  end
+
+  def default_positions
+    { before_head_close: :render }
   end
 end

--- a/lib/rack/tracker/vwo/vwo.rb
+++ b/lib/rack/tracker/vwo/vwo.rb
@@ -2,4 +2,8 @@ class Rack::Tracker::Vwo <  Rack::Tracker::Handler
   def render
     Tilt.new( File.join( File.dirname(__FILE__), 'template', 'vwo.erb') ).render(self)
   end
+
+  def default_positions
+    { before_head_close: :render }
+  end
 end

--- a/lib/rack/tracker/zanox/zanox.rb
+++ b/lib/rack/tracker/zanox/zanox.rb
@@ -21,8 +21,6 @@ class Rack::Tracker::Zanox < Rack::Tracker::Handler
 
   Sale = Class.new(Lead)
 
-  self.position = :body
-
   def mastertag
     # First event should be stronger, e.g. one signs up and gets redirected to homepage
     # "sign up" should be tracked instead of "view homepage"
@@ -44,5 +42,9 @@ class Rack::Tracker::Zanox < Rack::Tracker::Handler
   # this is called with additional arguments to t.zanox
   def self.track(name, *event)
     { name.to_s => [event.last.merge('class_name' => event.first.to_s.capitalize)] }
+  end
+
+  def default_positions
+    { before_body_close: :render }
   end
 end

--- a/spec/handler/criteo_spec.rb
+++ b/spec/handler/criteo_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe Rack::Tracker::Criteo do
   end
 
   it 'will be placed in the body' do
-    expect(described_class.position).to eq(:body)
-    expect(described_class.new(env).position).to eq(:body)
+    expect(described_class.new(env).positions.keys.first).to eq(:before_body_close)
   end
 
   describe '#render' do

--- a/spec/handler/facebook_spec.rb
+++ b/spec/handler/facebook_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe Rack::Tracker::Facebook do
   end
 
   it 'will be placed in the body' do
-    expect(described_class.position).to eq(:body)
-    expect(described_class.new(env).position).to eq(:body)
+    expect(described_class.new(env).positions.keys.first).to eq(:before_body_close)
   end
 
   describe 'with custom audience id' do

--- a/spec/handler/go_squared_spec.rb
+++ b/spec/handler/go_squared_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Rack::Tracker::GoSquared do
   end
 
   it 'will be placed in the head' do
-    expect(described_class.position).to eq(:head)
-    expect(described_class.new(env).position).to eq(:head)
+    expect(described_class.new(env).positions.keys.first).to eq(:before_head_close)
   end
 
   describe "with events" do

--- a/spec/handler/google_adwords_conversion_spec.rb
+++ b/spec/handler/google_adwords_conversion_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe Rack::Tracker::GoogleAdwordsConversion do
   end
 
   it 'will be placed in the body' do
-    expect(described_class.position).to eq(:body)
-    expect(described_class.new(env).position).to eq(:body)
-    expect(described_class.new(env, position: :body).position).to eq(:body)
+    expect(described_class.new(env).positions.keys.first).to eq(:before_body_close)
+    expect(described_class.new(env, positions: { before_body_close: :render }).positions.keys.first).to eq(:before_body_close)
   end
 
   describe "with events" do

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
   end
 
   it 'will be placed in the head' do
-    expect(described_class.position).to eq(:head)
-    expect(described_class.new(env).position).to eq(:head)
-    expect(described_class.new(env, position: :body).position).to eq(:body)
+    expect(described_class.new(env).positions.keys.first).to eq(:before_head_close)
+    expect(described_class.new(env, positions: { after_body_open: :render_body }).positions.keys.first).to eq(:after_body_open)
   end
 
   describe '#ecommerce_events' do

--- a/spec/handler/google_tag_manager_spec.rb
+++ b/spec/handler/google_tag_manager_spec.rb
@@ -7,10 +7,15 @@ RSpec.describe Rack::Tracker::GoogleTagManager do
     }
   end
 
-  it 'will be placed in the body by default' do
-    expect(described_class.position).to eq(:body)
-    expect(described_class.new(env).position).to eq(:body)
-    expect(described_class.new(env, position: :head).position).to eq(:head)
+  # it 'will be placed in the body by default' do
+  #   expect(described_class.position).to eq(:body)
+  #   expect(described_class.new(env).position).to eq(:body)
+  #   expect(described_class.new(env, position: :head).position).to eq(:head)
+  # end
+
+  it 'body content will be placed after body open by default' do
+    expect(described_class.new(env).positions.keys.last).to eq(:after_body_open)
+    expect(described_class.new(env, positions: { after_head_open: :render_body }).positions.keys.last).to eq(:after_head_open)
   end
 
   describe "with events" do
@@ -23,7 +28,7 @@ RSpec.describe Rack::Tracker::GoogleTagManager do
         }}
       end
 
-      subject { described_class.new(env, container: 'somebody').render }
+      subject { described_class.new(env, container: 'somebody').render_head }
       it "will show events" do
         expect(subject).to match(%r{"page":"Cart","price":50,"content_ids":\["sku_1","sku_2","sku_3"\]})
       end
@@ -31,7 +36,7 @@ RSpec.describe Rack::Tracker::GoogleTagManager do
   end
 
   describe "with dynamic tracker" do
-    subject { described_class.new(env, { container: lambda { |env| return env[:misc] }}).render }
+    subject { described_class.new(env, { container: lambda { |env| return env[:misc] }}).render_head }
 
     it 'will call tracker lambdas to obtain tracking codes' do
       expect(subject).to match(%r{\(window,document,'script','dataLayer','foobar'\)})

--- a/spec/handler/vwo_spec.rb
+++ b/spec/handler/vwo_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Rack::Tracker::Vwo do
   end
 
   it 'will be placed in the head' do
-    expect(described_class.position).to eq(:head)
-    expect(described_class.new(env).position).to eq(:head)
+    expect(described_class.new(env).positions.keys.first).to eq(:before_head_close)
   end
 
 end

--- a/spec/handler/zanox_spec.rb
+++ b/spec/handler/zanox_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe Rack::Tracker::Zanox do
   end
 
   it 'will be placed in the body' do
-    expect(described_class.position).to eq(:body)
-    expect(described_class.new(env).position).to eq(:body)
+    expect(described_class.new(env).positions.keys.first).to eq(:before_body_close)
   end
 
   describe '#render #sale_events' do

--- a/spec/integration/criteo_integration_spec.rb
+++ b/spec/integration/criteo_integration_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Criteo Integration" do
   describe 'adjust tracker position via options' do
     before do
       setup_app(action: :criteo) do |tracker|
-        tracker.handler :criteo, { set_account: '1234', position: :head }
+        tracker.handler :criteo, { set_account: '1234', positions: { before_head_close: :render } }
       end
       visit '/'
     end

--- a/spec/integration/google_analytics_integration_spec.rb
+++ b/spec/integration/google_analytics_integration_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Google Analytics Integration" do
   describe 'adjust tracker position via options' do
     before do
       setup_app(action: :google_analytics) do |tracker|
-        tracker.handler :google_analytics, { tracker: 'U-XXX-Y', position: :body }
+        tracker.handler :google_analytics, { tracker: 'U-XXX-Y', positions: { before_body_close: :render} }
       end
       visit '/'
     end

--- a/spec/integration/google_tag_manager_integration_spec.rb
+++ b/spec/integration/google_tag_manager_integration_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe "Google Tag Manager Integration" do
   subject { page }
 
   it "embeds the script tag with tracking event from the controller action" do
-    expect(page.find("body")).to have_content 'GTM-ABCDEF'
-    expect(page.find("body")).to have_content "dataLayer.push( {\"click\":\"X\",\"price\":10}, {\"transactionProducts\":[{\"sku\":\"DD44\",\"name\":\"T-shirt\"},{\"sku\":\"DD66\",\"name\":\"Jeans\"}]} );"
+    expect(page.find("head").native.text).to include 'GTM-ABCDEF'
+    expect(find(:xpath, "//iframe")['src']).to include 'GTM-ABCDEF'
+    expect(page.find("head").native.text).to include "dataLayer.push(\n  {\"click\":\"X\",\"price\":10}, {\"transactionProducts\":[{\"sku\":\"DD44\",\"name\":\"T-shirt\"},{\"sku\":\"DD66\",\"name\":\"Jeans\"}]}\n);"
   end
 
 end

--- a/spec/support/fake_handler.rb
+++ b/spec/support/fake_handler.rb
@@ -10,11 +10,16 @@ class TrackAllTheThings < Rack::Tracker::Handler
   def track_me
     env['tracker']['track_all_the_things']
   end
+
+  def default_positions
+    {
+      before_head_close: :render
+    }
+  end
 end
 
 
 class AnotherHandler < Rack::Tracker::Handler
-  self.position = :body
 
   def render
     Tilt.new( File.join( File.dirname(__FILE__), '../fixtures/another_handler.erb') ).render(self)
@@ -26,5 +31,9 @@ class AnotherHandler < Rack::Tracker::Handler
 
   def track_me
     env['tracker']['another_handler']
+  end
+
+  def default_positions
+    { before_body_close: :render }
   end
 end

--- a/spec/tracker/tracker_spec.rb
+++ b/spec/tracker/tracker_spec.rb
@@ -9,7 +9,9 @@ class DummyHandler < Rack::Tracker::Handler
 end
 
 class BodyHandler < DummyHandler
-  self.position = :body
+  def default_positions
+    { before_body_close: :render }
+  end
 end
 
 RSpec.describe Rack::Tracker do


### PR DESCRIPTION
Add possibility to render snippets in different positions.