### PR TITLE
Facebook pixel track custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,15 @@ Will result in the following:
   fbq("track", "Purchase", {"value":"100.0","currency":"USD"});
 ```
 
+You can also use non-standard (custom) event names for audience building when you do not need to track or optimize for conversions.
+
+```
+  tracker do |t|
+    t.facebook_pixel :track_custom, { type: 'FrequentShopper', options: { purchases: 24, category: 'Sport' } }
+  end
+```
+
+
 ### Visual website Optimizer (VWO)
 Just integrate the handler with your matching account_id and you will be ready to go
 

--- a/lib/rack/tracker/facebook_pixel/facebook_pixel.rb
+++ b/lib/rack/tracker/facebook_pixel/facebook_pixel.rb
@@ -1,4 +1,6 @@
 class Rack::Tracker::FacebookPixel < Rack::Tracker::Handler
+  self.position = :body
+
   class Event < OpenStruct
     def write
       options.present? ? type_to_json << options_to_json : type_to_json
@@ -15,9 +17,15 @@ class Rack::Tracker::FacebookPixel < Rack::Tracker::Handler
     end
   end
 
-  self.position = :body
+  class Track < Event
+    def name
+      'track'
+    end
+  end
 
-  def self.track(name, *event)
-    { name.to_s => [event.last.merge('class_name' => 'Event')] }
+  class TrackCustom < Event
+    def name
+      'trackCustom'
+    end
   end
 end

--- a/lib/rack/tracker/facebook_pixel/template/facebook_pixel.erb
+++ b/lib/rack/tracker/facebook_pixel/template/facebook_pixel.erb
@@ -18,7 +18,7 @@
 <% if events.any? %>
   <script type="text/javascript">
     <% events.each do |event| %>
-      fbq("track", <%= event.write %>);
+      fbq("<%= event.name %>", <%= event.write %>);
     <% end %>
   </script>
 <% end %>

--- a/lib/rack/tracker/go_squared/go_squared.rb
+++ b/lib/rack/tracker/go_squared/go_squared.rb
@@ -26,8 +26,4 @@ class Rack::Tracker::GoSquared < Rack::Tracker::Handler
   def visitor_info
     events.select{|e| e.kind_of?(VisitorInfo) }.first
   end
-
-  def self.track(name, *event)
-    { name.to_s => [event.last.merge('class_name' => event.first.to_s.classify)] }
-  end
 end

--- a/lib/rack/tracker/google_adwords_conversion/google_adwords_conversion.rb
+++ b/lib/rack/tracker/google_adwords_conversion/google_adwords_conversion.rb
@@ -1,11 +1,6 @@
 class Rack::Tracker::GoogleAdwordsConversion < Rack::Tracker::Handler
-
   class Conversion < OpenStruct
   end
 
   self.position = :body
-
-  def self.track(name, *event)
-    { name.to_s => [event.last.merge('class_name' => event.first.to_s.capitalize)] }
-  end
 end

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -74,8 +74,4 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
   def enhanced_ecommerce_events
     events.select {|e| e.kind_of?(EnhancedEcommerce) }
   end
-
-  def self.track(name, *event)
-    { name.to_s => [event.last.merge('class_name' => event.first.to_s.classify)] }
-  end
 end

--- a/lib/rack/tracker/google_tag_manager/google_tag_manager.rb
+++ b/lib/rack/tracker/google_tag_manager/google_tag_manager.rb
@@ -30,8 +30,4 @@ class Rack::Tracker::GoogleTagManager < Rack::Tracker::Handler
   def render_body
     Tilt.new( File.join( File.dirname(__FILE__), 'template', 'google_tag_manager_body.erb') ).render(self)
   end
-
-  def self.track(name, *event)
-    { name.to_s => [event.last.merge('class_name' => event.first.to_s.capitalize)] }
-  end
 end

--- a/lib/rack/tracker/handler.rb
+++ b/lib/rack/tracker/handler.rb
@@ -4,8 +4,9 @@ class Rack::Tracker::Handler
       new(env).write_event(track(method_name, *args, &block))
     end
 
-    def track(name, event)
-      raise NotImplementedError.new("class method `#{__callee__}` is not implemented.")
+    # overwrite me in the handler subclass if you need more control over the event
+    def track(name, *event)
+      { name.to_s => [event.last.merge('class_name' => event.first.to_s.classify)] }
     end
   end
 

--- a/lib/rack/tracker/handler.rb
+++ b/lib/rack/tracker/handler.rb
@@ -26,8 +26,8 @@ class Rack::Tracker::Handler
   end
 
   def events
-    events = env.fetch('tracker', {})[self.class.to_s.demodulize.underscore] || []
-    events.map{ |ev| "#{self.class}::#{ev['class_name']}".constantize.new(ev.except('class_name')) }
+    events = env.fetch('tracker', {})[handler_name] || []
+    events.map { |ev| "#{self.class}::#{ev['class_name']}".constantize.new(ev.except('class_name')) }
   end
 
   def render

--- a/lib/rack/tracker/zanox/zanox.rb
+++ b/lib/rack/tracker/zanox/zanox.rb
@@ -36,9 +36,4 @@ class Rack::Tracker::Zanox < Rack::Tracker::Handler
   def sale_events
     events.select{ |event| event.class.to_s.demodulize == 'Sale' }
   end
-
-  # this is called with additional arguments to t.zanox
-  def self.track(name, *event)
-    { name.to_s => [event.last.merge('class_name' => event.first.to_s.capitalize)] }
-  end
 end

--- a/spec/handler/facebook_pixel_spec.rb
+++ b/spec/handler/facebook_pixel_spec.rb
@@ -1,13 +1,4 @@
 RSpec.describe Rack::Tracker::FacebookPixel do
-  # describe Rack::Tracker::FacebookPixel::Event do
-
-  #   subject { described_class.new({id: 'id', foo: 'bar'}) }
-
-  #   describe '#write' do
-  #     specify { expect(subject.write).to eq(['track', 'id', {foo: 'bar'}].to_json) }
-  #   end
-  # end
-
   def env
     {}
   end
@@ -37,11 +28,19 @@ RSpec.describe Rack::Tracker::FacebookPixel do
           [
             {
               'type' => 'Purchase',
-              'class_name' => 'Event',
+              'class_name' => 'Track',
               'options' =>
                 {
                   'value' => '23',
                   'currency' => 'EUR'
+                }
+            },{
+              'type' => 'FrequentShopper',
+              'class_name' => 'TrackCustom',
+              'options' =>
+                {
+                  'purchases' => 8,
+                  'category' => 'Sport'
                 }
             }
           ]
@@ -52,6 +51,7 @@ RSpec.describe Rack::Tracker::FacebookPixel do
 
     it 'will push the tracking events to the queue' do
       expect(subject).to match(%r{"track", "Purchase", \{"value":"23","currency":"EUR"\}})
+      expect(subject).to match(%r{"trackCustom", "FrequentShopper", \{"purchases":8,"category":"Sport"\}})
     end
 
     it 'will add the noscript fallback' do

--- a/spec/integration/facebook_pixel_integration_spec.rb
+++ b/spec/integration/facebook_pixel_integration_spec.rb
@@ -14,4 +14,13 @@ RSpec.describe "Facebook Pixel Integration" do
     expect(page).to have_content("fbq('init', 'PIXEL_ID');")
     expect(page.body).to include('https://www.facebook.com/tr?id=PIXEL_ID&ev=PageView&noscript=1')
   end
+
+  it 'tracks multiple events' do
+    expect(page.body).to match(/fbq\("track", "Purchase", {\"value\":42,\"currency\":\"USD\"}\);/)
+    expect(page.body).to match(/fbq\("track", "CompleteRegistration", {\"value\":0.75,\"currency\":\"EUR\"}\);/)
+  end
+
+  it "can use non-standard event names for audience building" do
+    expect(page.body).to match(/fbq\("trackCustom", "FrequentShopper", {\"purchases\":24,\"category\":\"Sport\"}/)
+  end
 end

--- a/spec/support/metal_controller.rb
+++ b/spec/support/metal_controller.rb
@@ -43,7 +43,9 @@ class MetalController < ActionController::Metal
 
   def facebook_pixel
     tracker do |t|
-      t.facebook_pixel :track, { id: 'conversion-event', value: '1', currency: 'EUR' }
+      t.facebook_pixel :track, { type: 'Purchase', options: { value: 42, currency: 'USD' } }
+      t.facebook_pixel :track, { type: 'CompleteRegistration', options: { value: 0.75, currency: 'EUR' } }
+      t.facebook_pixel :track_custom, { type: 'FrequentShopper', options: { purchases: 24, category: 'Sport' } }
     end
     render "metal/index"
   end


### PR DESCRIPTION
this should close: https://github.com/railslove/rack-tracker/issues/92

```
if you are not interested in tracking or optimizing for conversions,
you can pass custom event names into the trackCustom call.
```
https://developers.facebook.com/docs/ads-for-websites/pixel-events/v2.10#events

