### PR TITLE
Allow for dynamic Facebook Pixel options

### DIFF
--- a/lib/rack/tracker/facebook_pixel/facebook_pixel.rb
+++ b/lib/rack/tracker/facebook_pixel/facebook_pixel.rb
@@ -1,15 +1,7 @@
 class Rack::Tracker::FacebookPixel < Rack::Tracker::Handler
   self.position = :body
 
-  def tracker_options
-    @_tracker_options ||= {}.tap do |tracker_options|
-      options.each do |key, value|
-        if option_value = value.respond_to?(:call) ? value.call(env) : value
-          tracker_options[key] = option_value
-        end
-      end
-    end
-  end
+  ALLOWED_TRACKER_OPTIONS = [:id]
 
   class Event < OpenStruct
     def write

--- a/lib/rack/tracker/facebook_pixel/facebook_pixel.rb
+++ b/lib/rack/tracker/facebook_pixel/facebook_pixel.rb
@@ -1,6 +1,16 @@
 class Rack::Tracker::FacebookPixel < Rack::Tracker::Handler
   self.position = :body
 
+  def tracker_options
+    @_tracker_options ||= {}.tap do |tracker_options|
+      options.each do |key, value|
+        if option_value = value.respond_to?(:call) ? value.call(env) : value
+          tracker_options[key] = option_value
+        end
+      end
+    end
+  end
+
   class Event < OpenStruct
     def write
       options.present? ? type_to_json << options_to_json : type_to_json

--- a/lib/rack/tracker/facebook_pixel/facebook_pixel.rb
+++ b/lib/rack/tracker/facebook_pixel/facebook_pixel.rb
@@ -1,7 +1,6 @@
 class Rack::Tracker::FacebookPixel < Rack::Tracker::Handler
   self.position = :body
-
-  ALLOWED_TRACKER_OPTIONS = [:id]
+  self.allowed_tracker_options = [:id]
 
   class Event < OpenStruct
     def write

--- a/lib/rack/tracker/facebook_pixel/template/facebook_pixel.erb
+++ b/lib/rack/tracker/facebook_pixel/template/facebook_pixel.erb
@@ -7,12 +7,12 @@
     t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
     document,'script','//connect.facebook.net/en_US/fbevents.js');
 
-    fbq('init', '<%= options[:id] %>');
+    fbq('init', '<%= tracker_options[:id] %>');
     fbq('track', "PageView");
   }
 </script>
 <noscript>
-  <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=<%= options[:id] %>&ev=PageView&noscript=1"/>
+  <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=<%= tracker_options[:id] %>&ev=PageView&noscript=1"/>
 </noscript>
 
 <% if events.any? %>

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -70,4 +70,8 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
   def tracker_option_key(key)
     key.to_s.camelize(:lower).to_sym
   end
+
+  def tracker_option_value(value)
+    value.to_s
+  end
 end

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -1,6 +1,6 @@
 class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
 
-  ALLOWED_TRACKER_OPTIONS = [:cookie_domain, :user_id]
+  self.allowed_tracker_options = [:cookie_domain, :user_id]
 
   class Send < OpenStruct
     def initialize(attrs = {})

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -57,21 +57,17 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
     options[:tracker].respond_to?(:call) ? options[:tracker].call(env) : options[:tracker]
   end
 
-  def tracker_options
-    @tracker_options ||= {}.tap do |tracker_options|
-      options.slice(*ALLOWED_TRACKER_OPTIONS).each do |key, value|
-        if option_value = value.respond_to?(:call) ? value.call(env) : value
-          tracker_options[key.to_s.camelize(:lower).to_sym] = option_value.to_s
-        end
-      end
-    end
-  end
-
   def ecommerce_events
     events.select {|e| e.kind_of?(Ecommerce) }
   end
 
   def enhanced_ecommerce_events
     events.select {|e| e.kind_of?(EnhancedEcommerce) }
+  end
+
+  private
+
+  def tracker_option_key(key)
+    key.to_s.camelize(:lower).to_sym
   end
 end

--- a/lib/rack/tracker/handler.rb
+++ b/lib/rack/tracker/handler.rb
@@ -78,6 +78,6 @@ class Rack::Tracker::Handler
   # Transformations to be applied to tracker option values.
   # Override in descendants, if necessary.
   def tracker_option_value(value)
-    value.to_s
+    value
   end
 end

--- a/lib/rack/tracker/handler.rb
+++ b/lib/rack/tracker/handler.rb
@@ -56,4 +56,28 @@ class Rack::Tracker::Handler
   def handler_name
     self.class.name.demodulize.underscore
   end
+
+  def tracker_options
+    @_tracker_options ||= {}.tap do |tracker_options|
+      options.slice(*self.class::ALLOWED_TRACKER_OPTIONS).each do |key, value|
+        if option_value = value.respond_to?(:call) ? value.call(env) : value
+          tracker_options[tracker_option_key(key)] = tracker_option_value(option_value)
+        end
+      end
+    end
+  end
+
+  private
+
+  # Transformations to be applied to tracker option keys.
+  # Override in descendants, if necessary.
+  def tracker_option_key(key)
+    key.to_sym
+  end
+
+  # Transformations to be applied to tracker option values.
+  # Override in descendants, if necessary.
+  def tracker_option_value(value)
+    value.to_s
+  end
 end

--- a/lib/rack/tracker/handler.rb
+++ b/lib/rack/tracker/handler.rb
@@ -13,6 +13,9 @@ class Rack::Tracker::Handler
   class_attribute :position
   self.position = :head
 
+  class_attribute :allowed_tracker_options
+  self.allowed_tracker_options = []
+
   attr_accessor :options
   attr_accessor :env
 
@@ -59,7 +62,7 @@ class Rack::Tracker::Handler
 
   def tracker_options
     @_tracker_options ||= {}.tap do |tracker_options|
-      options.slice(*self.class::ALLOWED_TRACKER_OPTIONS).each do |key, value|
+      options.slice(*allowed_tracker_options).each do |key, value|
         if option_value = value.respond_to?(:call) ? value.call(env) : value
           tracker_options[tracker_option_key(key)] = tracker_option_value(option_value)
         end

--- a/spec/handler/facebook_pixel_spec.rb
+++ b/spec/handler/facebook_pixel_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Rack::Tracker::FacebookPixel do
   def env
-    {}
+    { 'PIXEL_ID' => 'DYNAMIC_PIXEL_ID' }
   end
 
   it 'will be placed in the body' do
@@ -8,7 +8,7 @@ RSpec.describe Rack::Tracker::FacebookPixel do
     expect(described_class.new(env).position).to eq(:body)
   end
 
-  describe 'with id' do
+  describe 'with static id' do
     subject { described_class.new(env, id: 'PIXEL_ID').render }
 
     it 'will push the tracking events to the queue' do
@@ -17,6 +17,18 @@ RSpec.describe Rack::Tracker::FacebookPixel do
 
     it 'will add the noscript fallback' do
       expect(subject).to match(%r{https://www.facebook.com/tr\?id=PIXEL_ID&ev=PageView&noscript=1})
+    end
+  end
+
+  describe 'with dynamic id' do
+    subject { described_class.new(env, id: lambda { |env| env['PIXEL_ID'] }).render }
+
+    it 'will push the tracking events to the queue' do
+      expect(subject).to match(%r{fbq\('init', 'DYNAMIC_PIXEL_ID'\)})
+    end
+
+    it 'will add the noscript fallback' do
+      expect(subject).to match(%r{https://www.facebook.com/tr\?id=DYNAMIC_PIXEL_ID&ev=PageView&noscript=1})
     end
   end
 

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -53,28 +53,24 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
   end
 
   describe '#tracker_options' do
-    before do
-      stub_const("#{described_class}::ALLOWED_TRACKER_OPTIONS", [:some_option])
-    end
-
     context 'with an allowed option configured with a static value' do
-      subject { described_class.new(env, { some_option: 'value' }) }
+      subject { described_class.new(env, { user_id: 'value' }) }
 
       it 'returns hash with option set' do
-        expect(subject.tracker_options).to eql ({ someOption: 'value' })
+        expect(subject.tracker_options).to eql ({ userId: 'value' })
       end
     end
 
     context 'with an allowed option configured with a block' do
-      subject { described_class.new(env, { some_option: lambda { |env| return env[:misc] } }) }
+      subject { described_class.new(env, { user_id: lambda { |env| return env[:misc] } }) }
 
       it 'returns hash with option set' do
-        expect(subject.tracker_options).to eql ({ someOption: 'foobar' })
+        expect(subject.tracker_options).to eql ({ userId: 'foobar' })
       end
     end
 
     context 'with an allowed option configured with a block returning nil' do
-      subject { described_class.new(env, { some_option: lambda { |env| return env[:non_existing_key] } }) }
+      subject { described_class.new(env, { user_id: lambda { |env| return env[:non_existing_key] } }) }
 
       it 'returns an empty hash' do
         expect(subject.tracker_options).to eql ({})

--- a/spec/handler/handler_spec.rb
+++ b/spec/handler/handler_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe Rack::Tracker::Handler do
+  def env
+    { misc: 'foobar' }
+  end
+
+  describe '#tracker_options' do
+    before do
+      stub_const("#{described_class}::ALLOWED_TRACKER_OPTIONS", [:some_option])
+    end
+
+    context 'with an allowed option configured with a static value' do
+      subject { described_class.new(env, { some_option: 'value' }) }
+
+      it 'returns hash with option set' do
+        expect(subject.tracker_options).to eql ({ some_option: 'value' })
+      end
+    end
+
+    context 'with an allowed option configured with a block' do
+      subject { described_class.new(env, { some_option: lambda { |env| return env[:misc] } }) }
+
+      it 'returns hash with option set' do
+        expect(subject.tracker_options).to eql ({ some_option: 'foobar' })
+      end
+    end
+
+    context 'with an allowed option configured with a block returning nil' do
+      subject { described_class.new(env, { some_option: lambda { |env| return env[:non_existing_key] } }) }
+
+      it 'returns an empty hash' do
+        expect(subject.tracker_options).to eql ({})
+      end
+    end
+
+    context 'with a non allowed option' do
+      subject { described_class.new(env, { new_option: 'value' }) }
+
+      it 'returns an empty hash' do
+        expect(subject.tracker_options).to eql ({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows the Facebook Pixel id (as well as other tracker options) to be dynamic, and change on a per-request basis. It's based on some other trackers that offer this functionality (`:user_id` on the Google Analytics one, for example).