### PR TITLE
Add option to pass Google Optimize container ID to Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ request.env['tracker'] = {
 * `:advertising` - Enables [Display Features](https://developers.google.com/analytics/devguides/collection/analyticsjs/display-features).
 * `:ecommerce` - Enables [Ecommerce Tracking](https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce).
 * `:enhanced_ecommerce` - Enables [Enhanced Ecommerce Tracking](https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce)
+* `:optimize` - pass [Google Optimize container ID](https://support.google.com/360suite/optimize/answer/6262084#example-combined-snippet) as value (e.g. `optimize: 'GTM-1234'`).
 
 #### Events
 

--- a/lib/rack/tracker/google_analytics/template/google_analytics.erb
+++ b/lib/rack/tracker/google_analytics/template/google_analytics.erb
@@ -20,6 +20,9 @@
 <% if options[:ecommerce] %>
   ga('require', 'ecommerce', 'ecommerce.js');
 <% end %>
+<% if options[:optimize] %>
+  ga('require', '<%= options[:optimize] %>');
+<% end %>
 <% if options[:anonymize_ip] %>
   ga('set', 'anonymizeIp', true);
 <% end %>

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -235,6 +235,14 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
     end
   end
 
+  describe "with optimize" do
+    subject { described_class.new(env, tracker: 'happy', optimize: 'GTM-1234').render }
+
+    it "will require the optimize plugin with container ID" do
+      expect(subject).to match(%r{ga\('require', 'GTM-1234'\)})
+    end
+  end
+
   describe "with anonymizeIp" do
     subject { described_class.new(env, tracker: 'happy', anonymize_ip: true).render }
 


### PR DESCRIPTION
Great gem. I used it today in a project, but had to use a custom handler to include the Google Optimize plugin into the Google Analytics snippet - as per [these instructions](https://support.google.com/360suite/optimize/answer/6262084#example-combined-snippet). It didn't feel like the best implementation, so I thought I'd add an option to the Google Analytics handler.