### PR TITLE
Set wildcard to non-greedy for GTM body insertion

### DIFF
--- a/lib/rack/tracker/google_tag_manager/google_tag_manager.rb
+++ b/lib/rack/tracker/google_tag_manager/google_tag_manager.rb
@@ -13,7 +13,7 @@ class Rack::Tracker::GoogleTagManager < Rack::Tracker::Handler
     response.sub! %r{<head.*>} do |m|
       m.to_s << self.render_head
     end
-    response.sub! %r{<body.*>} do |m|
+    response.sub! %r{<body.*?>} do |m|
       m.to_s << self.render_body
     end
     response


### PR DESCRIPTION
Change introduced in #86 causes issues with mismatches of closing brackets (single elements vs separately closed elements `<input/>` vs `<div></div>`) - removing the greediness cleanly matches *just* the `<body>` tag - regardless of what's contained in it.

You can see the problem with this behavior in rubular `<body.*>` vs `<body.*?>` - use the below HTML - the first without the question mark will return most (but not all!) of the HTML - with the question mark *just* the body tag is returned in the match.

sample HTML code used to repro issue:
```html
<html lang="en" style="font-size: 10px"><head></head><body class="app"><div class="portlet box blue" id=""><div class="portlet-title"><div class="tools"></div><div class="caption">Edit Location</div><div class="actions">&nbsp;&nbsp;&nbsp;</div></div><div class="portlet-body"><form novalidate="novalidate" class="simple_form portlet-body form edit_service_location" id="edit_location_920" action="/en/locations/920" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="✓"><input type="hidden" name="_method" value="patch"><input type="hidden" name="authenticity_token" value="d05xw=="><div class="form-group text optional "><label class="control-label text optional" for="service_location_comment">Comment</label><textarea class="form-control text optional" name="service_location[comment]" id="service_location_comment">
</textarea></div></form></div></div></body></html>
```

Our users reported the issue when *some* (but not all, based on luck of the HTML) of our textarea elements would end up with the google tag manager code in addition to whatever would normally be there. any other mismatching html tags and the code would just have been in a random div on the page - no problem.