### PR TITLE
Respect Do Not Track (DNT) headers by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,32 @@ but to get you started we're shipping support for the following services out of 
 * [Zanox](#zanox)
 * [Hotjar](#hotjar)
 
+## Respecting the Do Not Track (DNT) HTTP header
+
+The Do Not Track (DNT) HTTP header is a HTTP header that requests the server to disable its tracking of the individual user.  
+This is an opt-out option supported by most browsers. This option is disabled by default and has to be explicitly enabled to indicate the user's request to opt-out. 
+We believe evey application should respect the user's choice to opt-out and respect this HTTP header. 
+
+Since version 2.0.0 rack-tracker respects that request header by default. That means NO tracker is injected IF the DNT header is set to "1".
+
+This option can be overwriten using the `DO_NOT_RESPECT_THE_USERS_CHOICE_TO_OPT_OUT => true` option which must be set on any handler that should ignore the DNT header. (but please think twice before doing that)
+
+### Example on how to not respect the DNT header
+
+```ruby
+use Rack::Tracker do
+  # this tracker will be injected EVEN IF the DNT header is set to 1
+  handler :maybe_a_friendly_tracker, { tracker: 'U-XXXXX-Y', DO_NOT_RESPECT_THE_USERS_CHOICE_TO_OPT_OUT: true }
+  # this tracker will NOT be injected if the DNT header is set to 1
+  handler :google_analytics, { tracker: 'U-XXXXX-Y' }
+end
+```
+
+Further reading on the DNT header: 
+
+* [Wikipedia Do Not Track](https://en.wikipedia.org/wiki/Do_Not_Track)
+* [EFF: Do Not Track](https://www.eff.org/issues/do-not-track)
+
 
 ## Installation
 

--- a/lib/rack/tracker/handler.rb
+++ b/lib/rack/tracker/handler.rb
@@ -38,6 +38,11 @@ class Rack::Tracker::Handler
   end
 
   def inject(response)
+    # default to not inject this tracker if the DNT HTTP header is set
+    # if the DO_NOT_RESPECT_THE_USERS_CHOICE_TO_OPT_OUT config is set the DNT header is ignored :( - please do respect the DNT header!
+    if self.dnt_header_opt_out? && !self.options.has_key?(:DO_NOT_RESPECT_THE_USERS_CHOICE_TO_OPT_OUT)
+      return response
+    end
     # Sub! is enough, in well formed html there's only one head or body tag.
     # Block syntax need to be used, otherwise backslashes in input will mess the output.
     # @see http://stackoverflow.com/a/4149087/518204 and https://github.com/railslove/rack-tracker/issues/50
@@ -68,6 +73,11 @@ class Rack::Tracker::Handler
         end
       end
     end
+  end
+
+  # the request has set the DO NOT TRACK (DNT) and has opted to get not tracked (DNT=1)
+  def dnt_header_opt_out?
+    self.env['DNT'] && self.env['DNT'].to_s == '1'
   end
 
   private

--- a/spec/tracker/tracker_spec.rb
+++ b/spec/tracker/tracker_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Rack::Tracker do
       use Rack::Tracker do
         handler DummyHandler, { foo: 'head' }
         handler BodyHandler, { foo: 'body' }
+        handler DummyHandler, { foo: 'I am evil', DO_NOT_RESPECT_THE_USERS_CHOICE_TO_OPT_OUT: true }
       end
 
       run lambda {|env|
@@ -104,5 +105,40 @@ RSpec.describe Rack::Tracker do
 
       expect(last_response.body).to_not include("alert('this is a dummy class');")
     end
+  end
+
+  describe 'do not track' do
+    context 'DNT header set to 1' do
+      it 'will not inject any tracker' do
+        get '/', {}, {'DNT' => 1 }
+
+        # the DummyHandler respects the DNT
+        expect(last_response.body).to_not include("console.log('head');")
+      end
+
+      it 'will allow the DO_NOT_RESPECT_THE_USERS_CHOICE_TO_OPT_OUT overwrite' do
+        get '/', {}, {'DNT' => 1 }
+
+        # the EvilHandler respects the DNT
+        expect(last_response.body).to include("console.log('I am evil');")
+      end
+    end
+
+    context 'DNT header set to 0' do
+      it 'injects all trackers' do
+        get '/', {}, {'DNT' => 0 }
+        expect(last_response.body).to include("console.log('head');")
+        expect(last_response.body).to include("console.log('I am evil');")
+      end
+    end
+
+    context 'DNT header is not set' do
+      it 'injects all trackers' do
+        get '/'
+        expect(last_response.body).to include("console.log('head');")
+        expect(last_response.body).to include("console.log('I am evil');")
+      end
+    end
+
   end
 end


### PR DESCRIPTION
The Do Not Track (DNT) header is the proposed HTTP header that requests
that a web application disable its tracking of an individual user.

This changes the default to respect the DNT header and no longer injects
any tracker if the DNT header is set to 1 (user opt-out).
This behaviour can be overwritten by setting the
DO_NOT_RESPECT_THE_USERS_CHOICE_TO_OPT_OUT option on handlers that
should still be injected.