### PR TITLE
dup response string in Rack::Tracker#inject to avoid RuntimeError

### DIFF
--- a/lib/rack/tracker.rb
+++ b/lib/rack/tracker.rb
@@ -58,10 +58,11 @@ module Rack
     def html?; @headers['Content-Type'] =~ /html/; end
 
     def inject(env, response)
+      duplicated_response = response.dup
       @handlers.each(env) do |handler|
-        handler.inject(response)
+        handler.inject(duplicated_response)
       end
-      response
+      duplicated_response
     end
 
     class HandlerSet

--- a/spec/tracker/tracker_spec.rb
+++ b/spec/tracker/tracker_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class DummyHandler < Rack::Tracker::Handler
   def render
     Tilt.new( File.join( File.dirname(__FILE__), '../fixtures/dummy.erb') ).render(self)
@@ -27,19 +28,19 @@ RSpec.describe Rack::Tracker do
         request = Rack::Request.new(env)
         case request.path
           when '/' then
-            [200, {'Content-Type' => 'application/html'}, ['<head>Hello world</head>'.freeze]]
+            [200, {'Content-Type' => 'application/html'}, ['<head>Hello world</head>']]
           when '/body' then
-            [200, {'Content-Type' => 'application/html'}, ['<body>bob here</body>'.freeze]]
+            [200, {'Content-Type' => 'application/html'}, ['<body>bob here</body>']]
           when '/body-head' then
-            [200, {'Content-Type' => 'application/html'}, ['<head></head><body></body>'.freeze]]
+            [200, {'Content-Type' => 'application/html'}, ['<head></head><body></body>']]
           when '/test.xml' then
-            [200, {'Content-Type' => 'application/xml'}, ['Xml here'.freeze]]
+            [200, {'Content-Type' => 'application/xml'}, ['Xml here']]
           when '/redirect' then
-            [302, {'Content-Type' => 'application/html', 'Location' => '/'}, ['<body>redirection</body>.freeze']]
+            [302, {'Content-Type' => 'application/html', 'Location' => '/'}, ['<body>redirection</body>']]
           when '/moved' then
-            [301, {'Content-Type' => 'application/html', 'Location' => '/redirect'}, ['<body>redirection</body>'.freeze]]
+            [301, {'Content-Type' => 'application/html', 'Location' => '/redirect'}, ['<body>redirection</body>']]
           else
-            [404, 'Nothing here'.freeze]
+            [404, 'Nothing here']
         end
       }
     end

--- a/spec/tracker/tracker_spec.rb
+++ b/spec/tracker/tracker_spec.rb
@@ -27,19 +27,19 @@ RSpec.describe Rack::Tracker do
         request = Rack::Request.new(env)
         case request.path
           when '/' then
-            [200, {'Content-Type' => 'application/html'}, ['<head>Hello world</head>']]
+            [200, {'Content-Type' => 'application/html'}, ['<head>Hello world</head>'.freeze]]
           when '/body' then
-            [200, {'Content-Type' => 'application/html'}, ['<body>bob here</body>']]
+            [200, {'Content-Type' => 'application/html'}, ['<body>bob here</body>'.freeze]]
           when '/body-head' then
-            [200, {'Content-Type' => 'application/html'}, ['<head></head><body></body>']]
+            [200, {'Content-Type' => 'application/html'}, ['<head></head><body></body>'.freeze]]
           when '/test.xml' then
-            [200, {'Content-Type' => 'application/xml'}, ['Xml here']]
+            [200, {'Content-Type' => 'application/xml'}, ['Xml here'.freeze]]
           when '/redirect' then
-            [302, {'Content-Type' => 'application/html', 'Location' => '/'}, ['<body>redirection</body>']]
+            [302, {'Content-Type' => 'application/html', 'Location' => '/'}, ['<body>redirection</body>.freeze']]
           when '/moved' then
-            [301, {'Content-Type' => 'application/html', 'Location' => '/redirect'}, ['<body>redirection</body>']]
+            [301, {'Content-Type' => 'application/html', 'Location' => '/redirect'}, ['<body>redirection</body>'.freeze]]
           else
-            [404, 'Nothing here']
+            [404, 'Nothing here'.freeze]
         end
       }
     end


### PR DESCRIPTION
Following up with issue #105 (RuntimeError: string modified), this PR ensures that when the response string is frozen, `Rack::Tracker#inject` does not cause a `RuntimeError` and still works as before.

In addition to using frozen strings in the gem specs, I used this version of `rack-tracker` locally in our app (referred to by @jblock in #105). Tests that were previously failing because of [this change in Rails 5.2](https://github.com/rails/rails/pull/29933) are now passing.

Hopefully this is enough to resolve the issue!