### PR TITLE
Allow to use custom pageview url script for GoogleAnalytics tracker.

### DIFF
--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -65,6 +65,10 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
     events.select {|e| e.kind_of?(EnhancedEcommerce) }
   end
 
+  def pageview_url_script
+    options[:pageview_url_script] || 'window.location.pathname + window.location.search'
+  end
+
   private
 
   def tracker_option_key(key)
@@ -73,9 +77,5 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
 
   def tracker_option_value(value)
     value.to_s
-  end
-
-  def pageview_url_script
-    options[:pageview_url_script] || 'window.location.pathname + window.location.search'
   end
 end

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -74,4 +74,8 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
   def tracker_option_value(value)
     value.to_s
   end
+
+  def pageview_url_script
+    options[:pageview_url_script] || 'window.location.pathname + window.location.search'
+  end
 end

--- a/lib/rack/tracker/google_analytics/template/google_analytics.erb
+++ b/lib/rack/tracker/google_analytics/template/google_analytics.erb
@@ -39,6 +39,6 @@
   ga('ecommerce:send');
 <% end %>
 <% if tracker %>
-  ga('send', 'pageview', window.location.pathname + window.location.search);
+  ga('send', 'pageview', <%= pageview_url_script %>);
 <% end %>
 </script>

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -267,4 +267,22 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
       expect(subject).to include %q{setTimeout(function() { ga('send', 'event', '30_seconds', 'read'); },30000)}
     end
   end
+
+  describe '#pageview_url_script' do
+    context 'without custom pageview url script' do
+      subject { described_class.new(env, {} ) }
+
+      it 'returns return the custom pageview url script' do
+        expect(subject.pageview_url_script).to eql ("window.location.pathname + window.location.search")
+      end
+    end
+
+    context 'with a custom pageview url script' do
+      subject { described_class.new(env, { pageview_url_script: "{ 'page': location.pathname + location.search + location.hash }"}) }
+
+      it 'returns return the custom pageview url script' do
+        expect(subject.pageview_url_script).to eql ("{ 'page': location.pathname + location.search + location.hash }")
+      end
+    end
+  end
 end

--- a/spec/integration/google_analytics_integration_spec.rb
+++ b/spec/integration/google_analytics_integration_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe "Google Analytics Integration" do
     expect(page.find("head")).to have_content('ga("send",{"hitType":"event","eventCategory":"button","eventAction":"click","eventLabel":"nav-buttons","eventValue":"X"})')
   end
 
+  it "will have default pageview url script" do
+    expect(page.find("head")).to have_content("ga('send', 'pageview', window.location.pathname + window.location.search);")
+  end
+
   describe 'adjust tracker position via options' do
     before do
       setup_app(action: :google_analytics) do |tracker|
@@ -49,4 +53,18 @@ RSpec.describe "Google Analytics Integration" do
       expect(page.find('head')).to have_content %q{Author\\'s name}
     end
   end
+
+  describe 'Use custom pageview script' do
+    before do
+      setup_app(action: :google_analytics) do |tracker|
+        tracker.handler :google_analytics, { tracker: 'U-XXX-Y', pageview_url_script: "{ 'page': location.pathname + location.search + location.hash }"}
+      end
+      visit '/'
+    end
+
+    it "will use the custom pageview script for the pageview event" do
+      expect(page.find("head")).to have_content("ga('send', 'pageview', { 'page': location.pathname + location.search + location.hash });")
+    end
+  end
+
 end


### PR DESCRIPTION
Hi, we use your gem in our project and we need to track (with google analytics) the hash part of the url in the pageview event. We found a solution in this stackoverflow thread : https://stackoverflow.com/a/4813223 .
I have simply added the option to the Google Analytics tracker for a custom pageview url script (which default to the old and normal url script).

I'm at your disposal if you need anything.