### PR TITLE
Update README.md for Google Analytics option `pageview_url_script`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ request.env['tracker'] = {
 * `:ecommerce` - Enables [Ecommerce Tracking](https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce).
 * `:enhanced_ecommerce` - Enables [Enhanced Ecommerce Tracking](https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce)
 * `:optimize` - pass [Google Optimize container ID](https://support.google.com/360suite/optimize/answer/6262084#example-combined-snippet) as value (e.g. `optimize: 'GTM-1234'`).
+* `:pageview_url_script` - a String containing a custom js script evaluating to the url that shoudl be given to the pageview event. Default to `window.location.pathname + window.location.search`.
 
 #### Events
 


### PR DESCRIPTION
I forgot to put some documentation in the README this in the previous PR (https://github.com/railslove/rack-tracker/pull/119) for the `pageview_url_script` option.