### PR TITLE
adds optimize_id to allowed tracker options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ request.env['tracker'] = {
 * `:link_attribution` - Enables [Enhanced Link Attribution](https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-link-attribution).
 * `:allow_display_features` - Can be used to disable [Display Features](https://developers.google.com/analytics/devguides/collection/gtagjs/display-features).
 * `:custom_map` - Used to [Configure and send custom dimensions](https://developers.google.com/analytics/devguides/collection/gtagjs/custom-dims-mets)
+* `:optimize_id` - Used to [Deploy Optimize using gtag](https://support.google.com/optimize/answer/7513085)
 * `:set` - Used in the [set command to configure multiple properties](https://developers.google.com/analytics/devguides/collection/gtagjs/setting-values)
 
 #### Trackers

--- a/lib/rack/tracker/google_global/google_global.rb
+++ b/lib/rack/tracker/google_global/google_global.rb
@@ -1,7 +1,7 @@
 class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
   self.allowed_tracker_options = [:cookie_domain, :user_id,
     :link_attribution, :allow_display_features, :anonymize_ip,
-    :custom_map]
+    :custom_map, :optimize_id]
 
   class Page < OpenStruct
     def params


### PR DESCRIPTION
Adds the possibility to integrate Google Optimize ID into the allowed tracker options