### PR TITLE
Add Hubspot integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ rack middleware that can be hooked up to multiple services and exposing them in 
 fashion. It comes in two parts, the first one is the actual middleware that you can add
 to the middleware stack the second part are the service-handlers that you're going to use
 in your application. It's easy to add your own [custom handlers](#custom-handlers),
-but to get you started we're shipping support for the services [mentioned below](#services) 
+but to get you started we're shipping support for the services [mentioned below](#services)
 out of the box:
 
 
@@ -591,6 +591,16 @@ tracker do |t|
     label: 'Standard',
     value: 10
   }
+end
+```
+
+### Hubspot
+
+[Hubspot](https://www.hubspot.com/)
+
+```
+config.middleware.use(Rack::Tracker) do
+  handler :hubspot, { site_id: '1234' }
 end
 ```
 

--- a/lib/rack/tracker.rb
+++ b/lib/rack/tracker.rb
@@ -24,6 +24,7 @@ require "rack/tracker/criteo/criteo"
 require "rack/tracker/zanox/zanox"
 require "rack/tracker/hotjar/hotjar"
 require "rack/tracker/bing/bing"
+require "rack/tracker/hubspot/hubspot"
 
 module Rack
   class Tracker

--- a/lib/rack/tracker/hubspot/hubspot.rb
+++ b/lib/rack/tracker/hubspot/hubspot.rb
@@ -1,0 +1,2 @@
+class Rack::Tracker::Hubspot < Rack::Tracker::Handler
+end

--- a/lib/rack/tracker/hubspot/template/hubspot.erb
+++ b/lib/rack/tracker/hubspot/template/hubspot.erb
@@ -1,0 +1,1 @@
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/<%= options[:site_id] %>.js"></script>

--- a/lib/rack/tracker/version.rb
+++ b/lib/rack/tracker/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class Tracker
-    VERSION = '1.9.0'
+    VERSION = '1.9.1'
   end
 end

--- a/spec/handler/hubspot_spec.rb
+++ b/spec/handler/hubspot_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Rack::Tracker::Hubspot do
+
+  def env
+    { misc: '42' }
+  end
+
+  it 'will be placed in the head' do
+    expect(described_class.position).to eq(:head)
+    expect(described_class.new(env).position).to eq(:head)
+  end
+end

--- a/spec/integration/hubspot_integration_spec.rb
+++ b/spec/integration/hubspot_integration_spec.rb
@@ -1,0 +1,19 @@
+require 'support/capybara_app_helper'
+
+RSpec.describe "Hubspot Integration" do
+  before do
+    setup_app(action: :hubspot) do |tracker|
+      tracker.handler :hubspot, { site_id: '123456' }
+    end
+
+    visit '/'
+  end
+
+
+  subject { page }
+
+  it "embeds the site-specifc script tag" do
+    expect(page).to have_xpath("//script", id: "hs-script-loader" )
+    expect(page.find("script")[:src]).to eq("//js.hs-scripts.com/123456.js")
+  end
+end

--- a/spec/support/metal_controller.rb
+++ b/spec/support/metal_controller.rb
@@ -117,6 +117,10 @@ class MetalController < ActionController::Metal
     render "metal/index"
   end
 
+  def hubspot
+    render "metal/index"
+  end
+
   def bing
     render "metal/index"
   end


### PR DESCRIPTION
First off, this package does a great job of consolidating the various trackers out there. For work, we need most of the things in here, along with Hubspot and a few others (PRs likely forthcoming). This specific change adds the Hubspot tracking code, as suggested in [their docuemntation](https://knowledge.hubspot.com/articles/kcs_article/reports/install-the-hubspot-tracking-code).