### PR TITLE
#137: Accepting all passed attributes for google_global tracking

### DIFF
--- a/lib/rack/tracker/google_global/google_global.rb
+++ b/lib/rack/tracker/google_global/google_global.rb
@@ -12,10 +12,10 @@ class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
   class Event < OpenStruct
     PREFIXED_PARAMS = %i[category label]
     LITERAL_PARAMS  = %i[value]
-    PARAMS = PREFIXED_PARAMS + LITERAL_PARAMS
+    SKIP_PARAMS  = %i[action]
 
     def params
-      Hash[to_h.slice(*PARAMS).map { |key, value| [param_key(key), value] }]
+      Hash[to_h.except(*SKIP_PARAMS).map { |key, value| [param_key(key), value] }]
     end
 
     private

--- a/lib/rack/tracker/google_global/google_global.rb
+++ b/lib/rack/tracker/google_global/google_global.rb
@@ -11,7 +11,6 @@ class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
 
   class Event < OpenStruct
     PREFIXED_PARAMS = %i[category label]
-    LITERAL_PARAMS  = %i[value]
     SKIP_PARAMS  = %i[action]
 
     def params

--- a/spec/handler/google_global_spec.rb
+++ b/spec/handler/google_global_spec.rb
@@ -210,13 +210,15 @@ RSpec.describe Rack::Tracker::GoogleGlobal do
               'action'     => 'login',
               'category'   => 'engagement',
               'label'      => 'Github',
-              'value'      => 5 }
+              'value'      => 5,
+              'transaction_id' => 1001,
+            }
           ]
         }}
       end
 
       it "will show event" do
-        expect(subject).to match(%r{gtag\('event', 'login', {\"event_category\":\"engagement\",\"event_label\":\"Github\",\"value\":5}\);})
+        expect(subject).to match(%r{gtag\('event', 'login', {\"event_category\":\"engagement\",\"event_label\":\"Github\",\"value\":5,\"transaction_id\":1001}\);})
       end
     end
   end


### PR DESCRIPTION
As agreed in #137 - made the change which will pass all the given attributes to the `gtag`.
It will only skip the `action` attribute, as that is used as a second argument already.

Please, would be awesome if you can merge this.

Thanks!