### PR TITLE
Add support for Drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,15 @@ config.middleware.use(Rack::Tracker) do
 end
 ```
 
+### Drift
+
+[Drift](https://www.drift.com/)
+
+```
+config.middleware.use(Rack::Tracker) do
+  handler :drift, account_id: 'DRIFT_ID'
+end
+```
 
 ### Custom Handlers
 

--- a/lib/rack/tracker.rb
+++ b/lib/rack/tracker.rb
@@ -25,6 +25,7 @@ require "rack/tracker/zanox/zanox"
 require "rack/tracker/hotjar/hotjar"
 require "rack/tracker/bing/bing"
 require "rack/tracker/hubspot/hubspot"
+require "rack/tracker/drift/drift"
 
 module Rack
   class Tracker

--- a/lib/rack/tracker/drift/drift.rb
+++ b/lib/rack/tracker/drift/drift.rb
@@ -1,0 +1,2 @@
+class Rack::Tracker::Drift < Rack::Tracker::Handler
+end

--- a/lib/rack/tracker/drift/template/drift.erb
+++ b/lib/rack/tracker/drift/template/drift.erb
@@ -1,0 +1,26 @@
+<script>
+"use strict";
+
+!function() {
+  var t = window.driftt = window.drift = window.driftt || [];
+  if (!t.init) {
+    if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
+    t.invoked = !0, t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on" ], 
+    t.factory = function(e) {
+      return function() {
+        var n = Array.prototype.slice.call(arguments);
+        return n.unshift(e), t.push(n), t;
+      };
+    }, t.methods.forEach(function(e) {
+      t[e] = t.factory(e);
+    }), t.load = function(t) {
+      var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
+      o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
+      var i = document.getElementsByTagName("script")[0];
+      i.parentNode.insertBefore(o, i);
+    };
+  }
+}();
+drift.SNIPPET_VERSION = '0.3.1';
+drift.load(<%= options[:account_id] %>);
+</script>

--- a/spec/handler/drift_spec.rb
+++ b/spec/handler/drift_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Rack::Tracker::Drift do
+  def env
+    { foo: 'bar' }
+  end
+
+  it 'will be placed in the head' do
+    expect(described_class.position).to eq(:head)
+    expect(described_class.new(env).position).to eq(:head)
+  end
+end

--- a/spec/integration/drift_integration_spec.rb
+++ b/spec/integration/drift_integration_spec.rb
@@ -1,0 +1,18 @@
+require 'support/capybara_app_helper'
+
+RSpec.describe 'Drift Integration' do
+  before do
+    setup_app(action: :drift) do |tracker|
+      tracker.handler :drift, account_id: 'DRIFT_ID'
+    end
+
+    visit '/'
+  end
+
+  subject { page }
+
+  it 'embeds the script with account_id' do
+    expect(page.find('script')).to have_content('js.driftt.com')
+    expect(page.find('script')).to have_content('DRIFT_ID')
+  end
+end

--- a/spec/support/metal_controller.rb
+++ b/spec/support/metal_controller.rb
@@ -124,4 +124,8 @@ class MetalController < ActionController::Metal
   def bing
     render "metal/index"
   end
+
+  def drift
+    render "metal/index"
+  end
 end


### PR DESCRIPTION
Add Drift tracking snippet per [their installation docs](https://gethelp.drift.com/hc/en-us/articles/360019349154-Install-Drift-on-Your-Website-Using-the-Javascript-Snippet).