### PR TITLE
Uncaught ReferenceError Fix: wrap Drift account ID in quotes

### DIFF
--- a/lib/rack/tracker/drift/template/drift.erb
+++ b/lib/rack/tracker/drift/template/drift.erb
@@ -22,5 +22,5 @@
   }
 }();
 drift.SNIPPET_VERSION = '0.3.1';
-drift.load(<%= options[:account_id] %>);
+drift.load('<%= options[:account_id] %>');
 </script>

--- a/spec/integration/drift_integration_spec.rb
+++ b/spec/integration/drift_integration_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe 'Drift Integration' do
 
   it 'embeds the script with account_id' do
     expect(page.find('script')).to have_content('js.driftt.com')
-    expect(page.find('script')).to have_content('DRIFT_ID')
+    expect(page.find('script')).to have_content('drift.load(\'DRIFT_ID\')')
   end
 end


### PR DESCRIPTION
Fixes issue with https://github.com/railslove/rack-tracker/pull/139

Thank you in advance!