### PR TITLE
Allow disabling explicit pageview sends for GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.11.2
+
+ * [ENHANCEMENT] Allows disabling the Google Analytics pageview send. Defaults to true.
+
 # 1.11.1
 
  * [BUGFIX] Uncaught ReferenceError Fix: wrap Drift account ID in quotes #140 (thx @sassela)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ end
 * `:enhanced_ecommerce` - Enables [Enhanced Ecommerce Tracking](https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce)
 * `:optimize` - pass [Google Optimize container ID](https://support.google.com/360suite/optimize/answer/6262084#example-combined-snippet) as value (e.g. `optimize: 'GTM-1234'`).
 * `:pageview_url_script` - a String containing a custom js script evaluating to the url that shoudl be given to the pageview event. Default to `window.location.pathname + window.location.search`.
+* `:explicit_pageview` - A boolean that controls whether to send the `pageview` event on pageload. This defaults to true.
 
 #### Events
 

--- a/lib/rack/tracker/google_analytics/google_analytics.rb
+++ b/lib/rack/tracker/google_analytics/google_analytics.rb
@@ -2,6 +2,11 @@ class Rack::Tracker::GoogleAnalytics < Rack::Tracker::Handler
 
   self.allowed_tracker_options = [:cookie_domain, :user_id]
 
+  def initialize(env, options = {})
+    options[:explicit_pageview] = true if !options.has_key?(:explicit_pageview)
+    super(env, options)
+  end
+
   class Send < OpenStruct
     def initialize(attrs = {})
       attrs.reverse_merge!(type: 'event')

--- a/lib/rack/tracker/google_analytics/template/google_analytics.erb
+++ b/lib/rack/tracker/google_analytics/template/google_analytics.erb
@@ -38,7 +38,7 @@
 <% if options[:ecommerce] && ecommerce_events.any? %>
   ga('ecommerce:send');
 <% end %>
-<% if tracker %>
+<% if tracker && options[:explicit_pageview] %>
   ga('send', 'pageview', <%= pageview_url_script %>);
 <% end %>
 </script>

--- a/lib/rack/tracker/version.rb
+++ b/lib/rack/tracker/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class Tracker
-    VERSION = '1.11.1'
+    VERSION = '1.11.2'
   end
 end

--- a/spec/handler/google_analytics_spec.rb
+++ b/spec/handler/google_analytics_spec.rb
@@ -284,5 +284,21 @@ RSpec.describe Rack::Tracker::GoogleAnalytics do
         expect(subject.pageview_url_script).to eql ("{ 'page': location.pathname + location.search + location.hash }")
       end
     end
+
+    context 'with explicit_pageview disabled' do
+      subject { described_class.new(env, {tracker: 'afake', explicit_pageview: false }).render }
+
+      it 'does not send a pageview event' do
+        expect(subject).not_to include %q{ga('send', 'pageview',}
+      end
+    end
+
+    context 'defaults to sending the pageview event' do
+      subject { described_class.new(env, {tracker: 'afake'}).render }
+
+      it 'does not send a pageview event' do
+        expect(subject).to include "ga('send', 'pageview'"
+      end
+    end
   end
 end


### PR DESCRIPTION
My colleague @gasi recently noticed that our site was both sending GA's standard `pageview` event, as well as submitting a separate `Page/view` event. We aren't particularly interested in sending the explicit `pageview`s, so I've added an override that allows callers to disable it.

The default is to still send the explicit `pageview` though, so this is backwards compatible. 