### PR TITLE
google global: better empty tracker handling

### DIFF
--- a/lib/rack/tracker/google_global/google_global.rb
+++ b/lib/rack/tracker/google_global/google_global.rb
@@ -48,7 +48,7 @@ class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
     options[:trackers].map(&method(:call_tracker)).reject(&method(:invalid_tracker?))
   end
 
-  def call_tracker tracker
+  def call_tracker(tracker)
     if tracker[:id].respond_to?(:call)
       tracker.merge(id: tracker[:id].call(env))
     else
@@ -56,7 +56,7 @@ class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
     end
   end
 
-  def invalid_tracker? tracker
+  def invalid_tracker?(tracker)
     tracker[:id].nil? || "" == tracker[:id].to_s.strip
   end
 

--- a/lib/rack/tracker/google_global/google_global.rb
+++ b/lib/rack/tracker/google_global/google_global.rb
@@ -35,7 +35,7 @@ class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
   end
 
   def trackers
-    options[:trackers].map { |tracker|
+    @_trackers ||= options[:trackers].map { |tracker|
       tracker[:id].respond_to?(:call) ? tracker.merge(id: tracker[:id].call(env)) : tracker
     }.reject { |tracker| tracker[:id].nil? || "" == tracker[:id].to_s.strip }
   end

--- a/lib/rack/tracker/google_global/google_global.rb
+++ b/lib/rack/tracker/google_global/google_global.rb
@@ -57,7 +57,7 @@ class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
   end
 
   def invalid_tracker?(tracker)
-    tracker[:id].nil? || "" == tracker[:id].to_s.strip
+    tracker[:id].to_s.strip == ''
   end
 
   def build_set_options

--- a/lib/rack/tracker/google_global/google_global.rb
+++ b/lib/rack/tracker/google_global/google_global.rb
@@ -37,7 +37,7 @@ class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
   def trackers
     options[:trackers].map { |tracker|
       tracker[:id].respond_to?(:call) ? tracker.merge(id: tracker[:id].call(env)) : tracker
-    }.reject { |tracker| tracker[:id].nil? }
+    }.reject { |tracker| tracker[:id].nil? || "" == tracker[:id].to_s.strip }
   end
 
   def set_options

--- a/lib/rack/tracker/google_global/google_global.rb
+++ b/lib/rack/tracker/google_global/google_global.rb
@@ -57,7 +57,16 @@ class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
   end
 
   def invalid_tracker?(tracker)
-    tracker[:id].to_s.strip == ''
+    if tracker[:id].to_s.strip == ''
+      $stdout.puts <<~WARN
+      WARNING: One of the trackers specified for Rack::Tracker handler 'google_global' is empty.
+               Trackers: #{options[:trackers]}
+      WARN
+
+      true
+    else
+      false
+    end
   end
 
   def build_set_options

--- a/lib/rack/tracker/google_global/google_global.rb
+++ b/lib/rack/tracker/google_global/google_global.rb
@@ -35,9 +35,7 @@ class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
   end
 
   def trackers
-    @_trackers ||= options[:trackers].map { |tracker|
-      tracker[:id].respond_to?(:call) ? tracker.merge(id: tracker[:id].call(env)) : tracker
-    }.reject { |tracker| tracker[:id].nil? || "" == tracker[:id].to_s.strip }
+    @_trackers ||= build_trackers
   end
 
   def set_options
@@ -45,6 +43,22 @@ class Rack::Tracker::GoogleGlobal < Rack::Tracker::Handler
   end
 
   private
+
+  def build_trackers
+    options[:trackers].map(&method(:call_tracker)).reject(&method(:invalid_tracker?))
+  end
+
+  def call_tracker tracker
+    if tracker[:id].respond_to?(:call)
+      tracker.merge(id: tracker[:id].call(env))
+    else
+      tracker
+    end
+  end
+
+  def invalid_tracker? tracker
+    tracker[:id].nil? || "" == tracker[:id].to_s.strip
+  end
 
   def build_set_options
     value = options[:set]

--- a/lib/rack/tracker/google_global/template/google_global.erb
+++ b/lib/rack/tracker/google_global/template/google_global.erb
@@ -1,4 +1,4 @@
-<% if trackers %>
+<% if trackers.any? %>
 <script async src='https://www.googletagmanager.com/gtag/js?id=<%= trackers[0][:id] %>'></script>
 <script>
   window.dataLayer = window.dataLayer || [];

--- a/spec/integration/google_global_integration_spec.rb
+++ b/spec/integration/google_global_integration_spec.rb
@@ -27,4 +27,17 @@ RSpec.describe "Google Global Integration Integration" do
      expect(page.find("body")).to have_content('U-XXX-Y')
     end
   end
+
+  describe "handles empty tracker id" do
+    before do
+      setup_app(action: :google_global) do |tracker|
+        tracker.handler :google_global, trackers: [{ id: nil }, { id: "" }, { id: "  " }]
+      end
+      visit '/'
+    end
+
+    it "does not inject scripts" do
+      expect(page.find("head")).not_to have_content("<script async src='https://www.googletagmanager.com/gtag/js?id=")
+    end
+  end
 end

--- a/spec/integration/google_global_integration_spec.rb
+++ b/spec/integration/google_global_integration_spec.rb
@@ -3,24 +3,19 @@ require 'support/capybara_app_helper'
 RSpec.describe "Google Global Integration Integration" do
   before do
     setup_app(action: :google_global) do |tracker|
-      tracker.handler :google_global, trackers: [{ id: 'U-XXX-Y' }]
+      tracker.handler :google_global, tracker_options
     end
     visit '/'
   end
 
-  subject { page }
+  let(:tracker_options) { { trackers: [{ id: 'U-XXX-Y' }] } }
 
   it "embeds the script tag with tracking event from the controller action" do
     expect(page.find("head")).to have_content('U-XXX-Y')
   end
 
   describe 'adjust tracker position via options' do
-    before do
-      setup_app(action: :google_global) do |tracker|
-        tracker.handler :google_global, trackers: [{ id: 'U-XXX-Y' }], position: :body
-      end
-      visit '/'
-    end
+    let(:tracker_options) { { trackers: [{ id: 'U-XXX-Y' }], position: :body } }
 
     it "will be placed in the specified tag" do
      expect(page.find("head")).to_not have_content('U-XXX-Y')
@@ -29,15 +24,10 @@ RSpec.describe "Google Global Integration Integration" do
   end
 
   describe "handles empty tracker id" do
-    before do
-      setup_app(action: :google_global) do |tracker|
-        tracker.handler :google_global, trackers: [{ id: nil }, { id: "" }, { id: "  " }]
-      end
-      visit '/'
-    end
+    let(:tracker_options) { { trackers: [{ id: nil }, { id: "" }, { id: "  " }] } }
 
     it "does not inject scripts" do
-      expect(page.find("head")).not_to have_content("<script async src='https://www.googletagmanager.com/gtag/js?id=")
+      expect(page.find("head")).to_not have_content("<script async src='https://www.googletagmanager.com/gtag/js?id=")
     end
   end
 end

--- a/spec/integration/google_global_integration_spec.rb
+++ b/spec/integration/google_global_integration_spec.rb
@@ -30,4 +30,12 @@ RSpec.describe "Google Global Integration Integration" do
       expect(page.find("head")).to_not have_content("<script async src='https://www.googletagmanager.com/gtag/js?id=")
     end
   end
+
+  describe "callable tracker id" do
+    let(:tracker_options) { { trackers: [{ id: proc { "U-XXX-Y" } }] } }
+
+    it "is injected into head with id from proc" do
+      expect(page.find("head")).to have_content('U-XXX-Y')
+    end
+  end
 end


### PR DESCRIPTION
i'm using the following code:

```rb
use Rack::Tracker do
  handler :google_global, trackers: [ { id: ENV["GA_ID"] } ], anonymize_ip: true
end
```

which throws up the following way if `GA_ID` is empty:

```
NoMethodError:
  undefined method `[]' for nil:NilClass
# ./lib/rack/tracker/google_global/template/google_global.erb:2:in `block in singleton class'
# ./lib/rack/tracker/google_global/template/google_global.erb:-2:in `instance_eval'
# ./lib/rack/tracker/google_global/template/google_global.erb:-2:in `singleton class'
# ./lib/rack/tracker/google_global/template/google_global.erb:-5:in `__tilt_70324565778440'
# ./lib/rack/tracker/handler.rb:37:in `render'
# ./lib/rack/tracker/handler.rb:50:in `block in inject'
# ./lib/rack/tracker/handler.rb:49:in `inject'
# ./lib/rack/tracker.rb:67:in `block in inject'
# ./lib/rack/tracker.rb:100:in `each'
# ./lib/rack/tracker.rb:100:in `each'
# ./lib/rack/tracker.rb:66:in `inject'
# ./lib/rack/tracker.rb:54:in `block in call'
# ./lib/rack/tracker.rb:54:in `call'
# ./spec/integration/google_global_integration_spec.rb:36:in `block (3 levels) in <top (required)>'
```

this patch properly handles the case of empty trackers in the templates and deals with a few other cases which should be considered "empty". also caches collected trackers in an ivar to save a few iterations and cleans up the integration test a little.