### PR TITLE
test on rails 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,9 @@ gemfile:
   - Gemfile.rails-4.2
   - Gemfile.rails-5.2
   - Gemfile.rails-6.0
+matrix:
+  exclude:
+  - rvm: 2.3.8
+    gemfile: Gemfile.rails-6.0
+  - rvm: 2.4.5
+    gemfile: Gemfile.rails-6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ gemfile:
   - Gemfile.rails-3.2
   - Gemfile.rails-4.2
   - Gemfile.rails-5.2
+  - Gemfile.rails-6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.5.3
   - 2.6.1
   - jruby-9.1.10.0
+  - jruby-9.2.7.0
 gemfile:
   - Gemfile
   - Gemfile.rails-3.2
@@ -17,4 +18,6 @@ matrix:
   - rvm: 2.3.8
     gemfile: Gemfile.rails-6.0
   - rvm: 2.4.5
+    gemfile: Gemfile.rails-6.0
+  - rvm: jruby-9.1.10.0
     gemfile: Gemfile.rails-6.0

--- a/Gemfile.rails-6.0
+++ b/Gemfile.rails-6.0
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem 'activesupport', '~> 6.0.0'
+gem 'actionpack', '~> 6.0.0'


### PR DESCRIPTION
also: [rails 3.2 is eol](https://guides.rubyonrails.org/maintenance_policy.html). should probably be dropped. will reduce ci time.