### PR TITLE
Make middleware thread safe

### DIFF
--- a/lib/rack/tracker.rb
+++ b/lib/rack/tracker.rb
@@ -38,6 +38,10 @@ module Rack
     end
 
     def call(env)
+      dup._call(env)
+    end
+
+    def _call(env)
       @status, @headers, @body = @app.call(env)
       return [@status, @headers, @body] unless html?
       response = Rack::Response.new([], @status, @headers)


### PR DESCRIPTION
We've noticed that in high traffic threaded environment (Puma) this middleware shares instance variables memory between threads and occasionally swaps ivars content.

In a worst-case scenario observed for a request from user A the response that was coming back was from a request made by a user B. If `Set-Cookie` header was present user A was immediately logged out and logged in as a user B (completely confusing users).

We've observed also a number of other requests/responses swaps which in general were hard to debug e.g. API request calls returning non-API responses.

This PR does not remove using of ivars (`@status`, `@headers`, `@body`) but rather duplicates the middleware calls. We are using forked repo for a few days now and we do not observe the issue anymore.

For more issues similar to this one you can check [here](https://github.com/rack/rack/issues/558) , [here](https://github.com/cerner/gc_stats/issues/3) and [here in SO thread](https://stackoverflow.com/questions/23028226/rack-middleware-and-thread-safety).

If this won't be planned for merging after all, maybe at least will save some time for others debugging similar symptoms.