### PR TITLE
Use leftmost match for gtm tag injection

### DIFF
--- a/lib/rack/tracker/google_tag_manager/google_tag_manager.rb
+++ b/lib/rack/tracker/google_tag_manager/google_tag_manager.rb
@@ -10,7 +10,7 @@ class Rack::Tracker::GoogleTagManager < Rack::Tracker::Handler
     # Sub! is enough, in well formed html there's only one head or body tag.
     # Block syntax need to be used, otherwise backslashes in input will mess the output.
     # @see http://stackoverflow.com/a/4149087/518204 and https://github.com/railslove/rack-tracker/issues/50
-    response.sub! %r{<head.*>} do |m|
+    response.sub! %r{<head.*?>} do |m|
       m.to_s << self.render_head
     end
     response.sub! %r{<body.*?>} do |m|

--- a/spec/handler/google_tag_manager_spec.rb
+++ b/spec/handler/google_tag_manager_spec.rb
@@ -32,4 +32,27 @@ RSpec.describe Rack::Tracker::GoogleTagManager do
     end
   end
 
+  describe '#inject' do
+    subject { handler_object.inject(example_response) }
+    let(:handler_object) { described_class.new(env, container: 'somebody') }
+
+    before do
+      allow(handler_object).to receive(:render_head).and_return('<script>"HEAD"</script>')
+      allow(handler_object).to receive(:render_body).and_return('<script>"BODY"</script>')
+    end
+
+    context 'with one line html response' do
+      let(:example_response) { "<html><head></head><body></body></html>" }
+
+      it 'will have render_head content in head tag' do
+        expect(subject).to match(%r{<head>.*<script>"HEAD"</script>.*</head>})
+      end
+
+      it 'will have render_body content in body tag' do
+        expect(subject).to match(%r{<body>.*<script>"BODY"</script>.*</body>})
+      end
+
+    end
+  end
+
 end


### PR DESCRIPTION
## Issue
If the response html has no new line after `<head>` tag,
the gtm script tag will be placed on a bad place.

### Example1

In case response html is

```
<html><head></head><body></body></html>
```

Then the response after `GoogleTagManager#inject` is being:

```
<html><head></head><body><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=somebody"
height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
</body></html>
  <script>
  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
  })(window,document,'script','dataLayer','somebody');</script>
```

### Example2
In case response html is

```
<html><head><script>console.log("hello");
console.log("world");
</script>
</head>
<body></body>
</html>
```

Then the response after `GoogleTagManager#inject` is being:

```
<html><head><script>
  <script>
  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
  })(window,document,'script','dataLayer','somebody');</script>


console.log("hello");
console.log("world");</script>
</head>
<body><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=somebody"
height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
</body>
</html>
```

## Solution

Use leftmost match for injection.