### PR TITLE
hotwired/turbo support and fixes issue with duplicate events in GTM

### DIFF
--- a/lib/rack/tracker/google_tag_manager/template/google_tag_manager_head.erb
+++ b/lib/rack/tracker/google_tag_manager/template/google_tag_manager_head.erb
@@ -17,6 +17,13 @@
         <% end %>
         dataLayer.push({'event':'pageView','virtualUrl': url});
       });
+      document.addEventListener('turbo:load', function(event) {
+        var url = event.detail.url;
+        <% if events.any? %>
+          dataLayer.push(<%= events.map(&:write).join(', ') %>);
+        <% end %>
+        dataLayer.push({'event':'pageView','virtualUrl': url});
+      });
     <% end %>
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/lib/rack/tracker/google_tag_manager/template/google_tag_manager_head.erb
+++ b/lib/rack/tracker/google_tag_manager/template/google_tag_manager_head.erb
@@ -1,30 +1,25 @@
 <% if container %>
-  <% unless options[:turbolinks] %>
-    <% if events.any? %>
-      <script>
-        dataLayer = [];
-        dataLayer.push(<%= events.map(&:write).join(', ') %>);
-      </script>
-    <% end %>
-  <% end %>
-
   <script>
+    dataLayer = [];
+
     <% if options[:turbolinks] %>
       document.addEventListener('turbolinks:load', function(event) {
-        var url = event.data.url;
-        <% if events.any? %>
-          dataLayer.push(<%= events.map(&:write).join(', ') %>);
-        <% end %>
         dataLayer.push({'event':'pageView','virtualUrl': url});
       });
       document.addEventListener('turbo:load', function(event) {
         var url = event.detail.url;
-        <% if events.any? %>
-          dataLayer.push(<%= events.map(&:write).join(', ') %>);
-        <% end %>
         dataLayer.push({'event':'pageView','virtualUrl': url});
       });
     <% end %>
+  </script>
+
+  <% if events.any? %>
+    <script>
+      dataLayer.push(<%= events.map(&:write).join(', ') %>);
+    </script>
+  <% end %>
+
+  <script>
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/lib/rack/tracker/google_tag_manager/template/google_tag_manager_head.erb
+++ b/lib/rack/tracker/google_tag_manager/template/google_tag_manager_head.erb
@@ -4,6 +4,7 @@
 
     <% if options[:turbolinks] %>
       document.addEventListener('turbolinks:load', function(event) {
+        var url = event.data.url;
         dataLayer.push({'event':'pageView','virtualUrl': url});
       });
       document.addEventListener('turbo:load', function(event) {
@@ -15,6 +16,9 @@
 
   <% if events.any? %>
     <script>
+      <%# Generates unique script tags to ensure that turbo/turbolinks include %>
+      <%# them in the document even if the same event happens more than once %>
+      // Unique Script ID: <%= SecureRandom.base64(8) %>
       dataLayer.push(<%= events.map(&:write).join(', ') %>);
     </script>
   <% end %>

--- a/spec/integration/google_tag_manager_integration_spec.rb
+++ b/spec/integration/google_tag_manager_integration_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Google Tag Manager Integration" do
     expect(page.find("body")).to have_xpath '//body/noscript/iframe[@src="https://www.googletagmanager.com/ns.html?id=GTM-ABCDEF"]'
   end
 
-  it "embeds the turbolinks observer if requested" do
+  it "embeds turbolinks and turbo observers if requested" do
     visit '/'
     expect(page.find("head")).to_not have_content "turbolinks:load"
     setup_app(action: :google_tag_manager) do |tracker|
@@ -31,5 +31,6 @@ RSpec.describe "Google Tag Manager Integration" do
     end
     visit '/'
     expect(page.find("head")).to have_content "turbolinks:load"
+    expect(page.find("head")).to have_content "turbo:load"
   end
 end


### PR DESCRIPTION
This PR adds support for the new `turbo-rails` gem that supersedes `turbolinks`. It observes both turbo and turbolinks events.

Also, this PR fixes issue with multiple event listeners tracking stale events and duplicate page views. Since turbo (and turbolinks) are evaluating new scripts from the `head` element, it ends up registering a duplicate event listener any time a new event is pushed from the backend. This PR fixes that by generating a static script with the turbo event listener (it will be evaluated only once) and a dynamic script with backend events (its going be evaluated on every load if any events are present).