### PR TITLE
Add user identity tracking for Heap

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,11 @@ config.middleware.use(Rack::Tracker) do
 end
 ```
 
+Other options:
+
+* `user_id` - This value will be used as the user identity
+* `reset_identity` - A truthy value will reset a user's identity to a random anonymous user ID
+
 ### Custom Handlers
 
 Tough we give you handlers for a few tracking services right out of the box, you might

--- a/lib/rack/tracker/heap/heap.rb
+++ b/lib/rack/tracker/heap/heap.rb
@@ -1,2 +1,3 @@
 class Rack::Tracker::Heap < Rack::Tracker::Handler
+  self.allowed_tracker_options = [:user_id, :reset_identity]
 end

--- a/lib/rack/tracker/heap/template/heap.erb
+++ b/lib/rack/tracker/heap/template/heap.erb
@@ -1,4 +1,10 @@
 <script>
   window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
   heap.load("<%= options[:env_id] %>");
+  <% if tracker_options[:reset_identity] %>
+  heap.resetIdentity();
+  <% end %>
+  <% if tracker_options[:user_id].present? %>
+  heap.identify("<%= tracker_options[:user_id] %>");
+  <% end %>
 </script>

--- a/spec/handler/heap_spec.rb
+++ b/spec/handler/heap_spec.rb
@@ -7,4 +7,62 @@ RSpec.describe Rack::Tracker::Heap do
     expect(described_class.position).to eq(:head)
     expect(described_class.new(env).position).to eq(:head)
   end
+
+  describe 'user_id tracker option' do
+    subject { described_class.new(env, { user_id: user_id }).render }
+
+    let(:user_id) { '123' }
+
+    it 'will include identify call with user_id value' do
+      expect(subject).to match(%r{heap.identify\("123"\);})
+    end
+
+    context 'when value is a proc' do
+      let(:user_id) { proc { '123' } }
+
+      it 'will include identify call with the user_id called value' do
+        expect(subject).to match(%r{heap.identify\("123"\);})
+      end
+    end
+
+    context 'when value is blank' do
+      let(:user_id) { '' }
+
+      it 'will not include identify call' do
+        expect(subject).not_to match(%r{heap.identify})
+      end
+    end
+  end
+
+  describe 'reset_identity tracker option' do
+    subject { described_class.new(env, tracker_options).render }
+
+    let(:tracker_options) do
+      { reset_identity: reset_identity? }.compact
+    end
+
+    context 'when true' do
+      let(:reset_identity?) { true }
+
+      it 'will include resetIdentity call' do
+        expect(subject).to match(%r{heap.resetIdentity\(\);})
+      end
+    end
+
+    context 'when false' do
+      let(:reset_identity?) { false }
+
+      it 'will not include resetIdentity call' do
+        expect(subject).not_to match(%r{heap.resetIdentity\(\);})
+      end
+    end
+
+    context 'when not given' do
+      let(:reset_identity?) { nil }
+
+      it 'will not include resetIdentity call' do
+        expect(subject).not_to match(%r{heap.resetIdentity\(\);})
+      end
+    end
+  end
 end

--- a/spec/integration/heap_integration_spec.rb
+++ b/spec/integration/heap_integration_spec.rb
@@ -3,7 +3,7 @@ require 'support/capybara_app_helper'
 RSpec.describe "Heap Integration" do
   before do
     setup_app(action: :heap) do |tracker|
-      tracker.handler :heap, { env_id: '12341234' }
+      tracker.handler :heap, options
     end
 
     visit '/'
@@ -11,7 +11,31 @@ RSpec.describe "Heap Integration" do
 
   subject { page }
 
+  let(:options) do
+    { env_id: '12341234' }
+  end
+
   it 'embeds the script with site_id' do
     expect(page).to have_content('heap.load("12341234");')
+  end
+
+  context 'with user_id tracker option' do
+    let(:options) do
+      { user_id: '345' }
+    end
+
+    it 'includes a call to identify' do
+      expect(page).to have_content('heap.identify("345");')
+    end
+  end
+
+  context 'with reset_identity tracker option' do
+    let(:options) do
+      { reset_identity: true }
+    end
+
+    it 'includes a call to resetIdentity' do
+      expect(page).to have_content('heap.resetIdentity();')
+    end
   end
 end


### PR DESCRIPTION
Adds support for [Heap identity management](https://developers.heap.io/reference/identify), which allows a unique identity to be attached to a user session to maintain history and unify profiles across sessions, devices, and browsers.

Implemented via tracker options `user_id` and `reset_identity`