### PR TITLE
chore: add ostruct as a dependency on ruby 3.x

### DIFF
--- a/rack-tracker.gemspec
+++ b/rack-tracker.gemspec
@@ -21,6 +21,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", ">= 1.4"
   spec.add_dependency "tilt", ">= 1.4"
   spec.add_dependency 'activesupport', '>= 3.0'
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0')
+    spec.add_dependency 'ostruct'
+  end
 
   spec.add_development_dependency 'actionpack', '>= 3.0'
   spec.add_development_dependency "bundler", ">= 1.16"
@@ -28,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "capybara", "~> 2.4"
   spec.add_development_dependency "pry"
-  if RUBY_VERSION < "2.0"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0')
     spec.add_development_dependency "mime-types", "< 3.0"
     spec.add_development_dependency "addressable", "< 2.5"
   end


### PR DESCRIPTION
This will be required to support Ruby 3.5.0, and is emitting a deprecation warning as of Ruby 3.3.5.

Also, changes version logic to use `Gem::Version` for the inevitable future when we reach Ruby 10.0.

Fixes #166